### PR TITLE
add `scipy` option to bandwidth optimization

### DIFF
--- a/explore hats.ipynb
+++ b/explore hats.ipynb
@@ -1,0 +1,918 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/lw17329/anaconda/envs/ana/lib/python3.5/site-packages/seaborn/apionly.py:6: UserWarning: As seaborn no longer sets a default style on import, the seaborn.apionly module is deprecated. It will be removed in a future version.\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pysal as ps\n",
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import shapely.geometry as geom\n",
+    "import seaborn.apionly as sns\n",
+    "import numpy as np\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "data = pd.read_csv(ps.examples.get_path('GData_utm.csv'))\n",
+    "data['geometry'] = [geom.Point(x,y) for x,y in data[['X','Y']].values]\n",
+    "data = gpd.GeoDataFrame(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f6139ebb358>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAARIAAAEACAYAAAB/KfmzAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJztnXuwHcV95z+/y8MSLwnMXcle7AiQ\nF4EEEbkyELtIVHHACiyUbYKSJeAlW1hlscS7YBcJcpkEFjvgEBtTMZtlA6VykAu0KICxl4eNIQ+b\n2JGCjXiuMZZ5ishYEhJ6APf2/jF90Oho7jk9Pd0zPef8PlVTumd+M9N9Rqe/0/37/aZbjDEoiqJU\nYaTpCiiK0n5USBRFqYwKiaIolVEhURSlMiokiqJURoVEUZTKqJAoilIZFRJFUSqjQqIoSmX2broC\nKXLooYeaWbNmNV0NRWmcNWvW/MIYM9rvOBWSAmbNmsXq1aubroaiNI6I/NzlOB3aKIpSGRUSRVEq\no0KiKEplVEgURamMComiKJVRIVG8mVh5LxPzzmRi+onZvyvvbbpKSkNo+FfxYmLlvfCpL8D2HdmO\n59fDp77ABDCyeFGjdVPqR3skih9X3rBLRDps35HtV4YOFZIBJurQ44VXyu1XBhoVkgHl7aHH8+vB\nmF1Dj1BictiMcvtRn8ogo0JSE7U3othDj8svhKlTdt83dUq2v4DowqY0igpJDTTSiAIMPXqJ38ji\nRXD9MnjPTBDJ/r1+2eSOVvWpDDQatamDXo0oVoTjsBmZYBXtd8AlKjOyeJF7/dWnMtBoj6QE3sOT\nPo3I5bqlyy459NiD0D0ID5+K0h5USBypNDzp0YhcrutTdumhRzehexBVhU1JGtElO/dkwYIFpns+\nkol5ZxYPFd4zk5HHvtHzensMEyBrRNcvy57wfa5bpWxfYpQ5sfLe7Pu+8EomrpdfqMlriSMia4wx\nC/odpz0SVyo8oXv2Dlyu24R/IUIPYmTxIkYe+wYjm36Q/asiMjCokLhScYw/aSNyuW6JskOFmSsP\njZShQoXElRJP6FKN2eW6jmWHDjP360FogpnSQYXEEdcndNnG7HJd595Bjbkart9TxWY4UGdrAUXO\nVleacIy+Xfb0E7NG3Y0II5t+ELYsh+/Zy8msQ6R2oM7Wpmgy8arOXA2X76nZrEODCklomky8ChRp\ncRqOuHxPzWYdGlRIQtNg4lWISIuzj8fle2o269CgQhKYpsOmlXM1HIcjTt8zVqRLSQ51thZQxdna\ndkI7bF2yWdUpmy7qbG0pjT+ZAw9HnHpI6pRtPSokCZHE5D9N+HjUKdt6VEhSIoEncyM+HnXKth6d\n2CglEnkyl5qwKASXX1jsI9EpBlqD9kgCUtm/EeDJ7FOHpv0yb/eCDpm2a+fUfWutg1INFZJABPFv\nVPRP+NQhCb9Mh+07d/39y9d61qNp8VN2R8O/BfiEf0O9Y1Nl8h+fOjT5bpBvPTRcXB8a/q2bQP6N\nSgllPnWI7Jdx7jmUqUcCTmlld5yEREQOE5E7RGSTiKwTkWUiItZ2lIh8R0S2iMj/E5Hzus49RUQe\nF5GdIvKkiCzqsl8iIi+KyHYReVBEjszZpojITSKyWUReE5HlIjI1Zz9cRB4QkR0i8pKIXFqm7KCk\nEHnwqYNnvV0nrHYeNpWpRyJOaWUXfYVEREaAu4Bx4ERgCfBp4FwR2dvaXgHGgGuB5SLyAXvuKHAH\ncDtwHLAKWCUiM639NOAq4GJgAfA6sDJX/JXAbwIftttvAJ/P2W8DttqyLwGuEJEzXcoOTgqTG/vU\nweMcZ4Eo03MoU48URFvZHWNMzw2YCxhgZm7fDWQNfp61zcjZHgT+3P79CWBdzibA88An7ecVwPKc\nfba93hz7+UXg/Jz9AmC9/ft99thZOfstwK0uZffaxsbGjA/jt91jxueeYcannZD9e9s9Xtepgk8d\nyp4zPvcMM37Q+/fc5p6x+3HTTig+btoJleoxfts9ZnzGybtfc8bJjdzvQQdYbfq0F2OMUx7JU8CB\nxpituX1vAvsD+9nPOXc723L7jwHW5kTLiMhaYE7OfkvO/oyIbAfmiMjLwLvz5wOPAjNEZLo9d6sx\nZl2X/RzHsoNTe/5FoDqUPsd1aFFykS7XeowsXsQE6Iz0CdF3aGOMGc+LiIjMJ2usNwP/CvwM+KyI\n7CMiJwO/RTacADgI2Nx1yY12fz9755jNXTZydt9rJ0+V8Gb00Kjr0CLicE9npE8L56iNiJxlewuP\nAHcbY1YZY94iE5X/DuwA/gH4K2PMP9rT9iq4lMmV28s+mY0+dpdr74GILBGR1SKyesOGDUWH1EaV\n3I5a8kIcBaLpKRWU+igT/r0PmA+cDZwuIktFZBqZn+OrZA7P84ALROR37DkTBWUI8JaDfaKgjmL/\n7dh9r70HxpgbjTELjDELRkdHiw4pRaVeQZXwpue5ZepbRiC05zAcOL9rY4c3TwNPi8hsYClZJGcE\nuNg6Zn4kIkcBnwXuAbYA7+q61HTgZfv3FuDgAvsma6PLPt3+u7nPuZ1r9yo7Gi4LcPekSnjT41yf\n+qbgD1LSwSX8u1BE1towcIdxMgfrvsBOKyIdtgGdfu8TwPGdc23uyTzg8Zx9LFfWEWSO2ieMMRuB\n9Xk7cCzwnDFmiz13iogc02XPX7tX2fGomjBVJbzpc26kBC/fXlkb3xcadlyGNo8CM4HrRGS2iCwE\nLiJzqN4H/IqIXCYiR4jIqcAfAXfac+8EDgCusT2VK8h6EZ2c5xXAR0TkPCsI1wEPG2OezdkvE5GT\nReQkYJndhzHmaWAN8BURmScii8mGXSscy45H1YSpKk5Kn3MjJHj5+mpa/77QkOIStfklsIgsqesR\n4GvAcuBaY8xPgDOAj5KFWm8E/ga42p77CvAx4HRrPwv4qDHmVWv/Jpk4XEMWAdqfXeFbgM8B3wa+\nBdwP/D2ZIHRYTOZUXU0mQsuMMfe7lB2VAMt7+jopvc6NkeDl28vxOU9T5htHX9oroOqcrW17qSxG\nfX3nfvU5r86FwYYNfWmvQdoW9oxSX99eTo3vCynhUCGJRNvCnsHr6+vnqel9ISUsKiRKELqjJoBX\nL8end9S2HuAgoj6SAoZ5XRsf2uYTUtxRH0lCDHyOg0ZNhh4Vksi0McehtPB5ZtMOtLgOGSoksWnZ\n09pL+EpGTdoorkpvVEhiU/Jp3fiT2kf4ykZNWiauSn9USGJT4mldJa08mPh4DFNKR008U/IbF1ll\nUlRIYlPmae3xpA4+TPBM7iqVh+JRhg6H0kaFJDKlntY+T+rQw4Q6krtO/eCumWVcy4g8HNLeTjV0\n7d8acJ67o+Qcp0DwN3djz4c6sfJe+Pq3ds11B5monHN67zI8fE2u36Hy/DGK9kiSwqc3EOE9k6jp\n/UU9CwPc/73e58X0NanztzIqJAnhlerdtvdMfHtQMX1NuuBWZVRIEqNsb6Dp90xK+xYqOHOj+Zr0\n7eHKqJBEpg4nXlNvGntFUir0oJy/Z1lhaFuvLkFUSCIy8CFLD99CLT2oksLQdK9uENC3fwsI9fbv\nxLwzi6Mw75nJyGPxp47tR5nIRuH5Cc9MVvW7KRn69m8KBHLilRkeuR4bpLeUsG+hbRNLtR0VkpgE\naGhlGnwpcXAYlvQVJfUtKBYVkpiEaGhl/BBlju3TW3IRJfUtKB00szUiQbJEywyPyhzbL4u2lyjl\n6q8r7imgPZLoVB6rlxkelTm2X28pkSSt1N6BSa0+qaBCkjplhkclju07LOkhSnU1ptTC56nVJyVU\nSBKnjB+irM+iZ29pMlE69YPejam0AHlOqxBN5PSdnEnRPJICdBb5jKJcDK68wSs3xmem+bJ5KlVm\ns3fJO0k5byYWmkeSMG0ZZxf2WHx9Jz5P87Lhc88eg/OQJeG8maZRIamZJsbZQYXLtzH5CFDZ8Hls\nkdO8mUlRIambmsfZwYXLtzF5CFDpPJXIIqd5M5PjJCQicpiI3CEim0RknYgsk4yHRMQUbG/lzj1F\nRB4XkZ0i8qSILOq69iUi8qKIbBeRB0XkyJxtiojcJCKbReQ1EVkuIlNz9sNF5AER2SEiL4nIpV3X\n7ll2I9QdVg0sXN6NyVOASoXPaxA5Tb0vpq+QiMgIcBcwDpwILAE+DZwLfAx4V9f2V8D/teeOAncA\ntwPHAauAVSIy09pPA64CLgYWAK8DK3PFXwn8JvBhu/0G8Pmc/TZgKzAGXAJcISJnupTdGHWPsyMI\nl09jquNpXrfIKTmMMT03YC7ZZHgzc/tuAFYWHLsPsB44zX7+BLAuZxfgeeCT9vMKYHnOPtuWNcd+\nfhE4P2e/AFhv/36fPXZWzn4LcKtL2b22sbExE4vx2+4x4zNONuMHvX/XNuNkM37bPWGuPfcMMz7t\nhOzfzud8WZ1t7hkBvs3gUHTvFGOA1aZPezHGOA1tngIONMbkY35vAvsXHPu7wA6gMwA/BlibEy1j\nP8+ZxP4MsB2YIyLTgHfn7cCjwAwRmW7P3WqMWddln+za3WU3Qqwn82S+EE79YN+nbVuiSFXp9T11\nyFKNvkJijBk3xmztfBaR+cA5wM0Fh18I/G9jzIT9fBCwueuYjXZ/P3vnmM1dNnJ232s3SpQf7WS+\nkPu/11O4hiVbM+b3HBYh7oVz1EZEzhKR7cAjwN3GmFVd9uOAk9hdYPYquJTJldvLPpmNPnaXa7cK\npx9qD19IT+EK6Iz1bVC1NMRI0bJhEeJ+lGlU9wHzgbOB00VkaZf9vwLfMMa8nNs3UVCGAG852Du9\nmpEuGzm777X3QESWiMhqEVm9YcOGokMaIXqyVMDJl3yXG62lIcaKlmnaPFBCSIwxW40xTxtjbge+\nDLwtJCJyEPAHwF93nbYFOLhr33Rgk4N9i/18cJcNsiFLlWvvgTHmRmPMAmPMgtHR0aJDmiF2slSo\nKJJvg6rQEEv1ZGJFyxJ5S7ppXMK/C0VkrQ0DdxgHduY+n08WrflO1+lPAMd3zhURAeYBj+fsY7my\njgD2A54wxmy01xzLXe9Y4DljzBZ77hQROabLnr92r7LbQexkqVChT98GVWFB8VI9mVghXk2bB9x6\nJI8CM4HrRGS2iCwELiLLz+iwFLjRRkby3AkcAFwjIkcBV5D1Ejpvd60APiIi51lBuA542BjzbM5+\nmYicLCInAcvsPowxTwNrgK+IyDwRWUw27FrhWHYjxFwHxtWJm68DV94A55zeU4Cc6uzboHzPK9mT\n2UNoD5kGU/eFJX9azS+jOSgZLjFisl7BQ2TDhefIGuVe1vYhst7J6CTnnkrWO3iDrDfwoS77Z4CX\nyMLGD7B7XshUMufta3a7CXhHzn4E8F177kvAxWXKnmyLlUfik0MSOu+k7PVcj/etp/d5004ozo+Z\ndkLwe+B0vQHNQcExj0SnESgg1jQCvstThFxaoWwdyhzvW0+f86os9ZH6MiEp4TqNgApJAdGEJIH5\nLErP8ZFAnYuoNPdIot8pRXQ+khRJwTFXtg4p1LmAShnCiX6nNqNCUicpOObK1iGFOk+Cd4Zwwt+p\nraiQ1EgK81n4zOvadJ1DU+d3Gpb0efWRFKBztg4vQR3bFfw4qaA+EuVt2vZUbKq+wdP1hyh9XoVk\nwHFtHKmITaMvwYVu+EOUPq9C0iC1vC3ruFh4mYXKy9Y5dH2jEbrhD1F0SIWkIWp7W9alcTg2Xp86\nR6lvLEI3/CGKDqmQNEVdb8u6NA7XxutT5xj1jUXghj+IEa/JUCFpirrelnVpHK6N16fOMeobiRgN\nf1imcFQhaYqa3pZ1ahyujdenzjHqG5FhafihUSFpCt8nr8d5/RqHc+P1qXOE+pYhlWjUwOPyivCw\nbTGXo8jj+/p5k6+t+5TdVH1jLv0xLKDTCPijma2DgU4XUB3NbFWUFieEtW1IpkIyZLTtB1qJBBLC\nfBP42rbEhQrJEFHHDzSGUHlfs+GEMO/73cJ3dFRIhonIP9AYQlXlmk2Hkr3vdwuHZOpsLWBQna2x\npxiM4dxss8PU936n9J3V2arsSWyfQYwnaQufzm/je79b+I6OCskwEfsHGkOoEnCYeuN5vxsfknmg\nQpIYMaMq0X+gMYQqkvjVEb2qcr9bl6rvkrU2bFtdma3dhMrEDJ1JWuZ6rsfGuGap76MZr06gma3+\nNOVsDeFkCz1PaIx5R5ueyzQlZ2bqqLO1jYRwLIYO8cYIGTedJ9FmB26iqJCkRAjHYuhGMoiRmAr3\neagyg0ugQpISIRyLoaMcgxiJ8bzPbUxdrwsVkoQIElUJHeVoUSTGFe/73PSQLGVcPLLDtjUVtQlF\n6MjJZMdViaY0OaeKL+PTTtg90tPZpp3QdNWigWPUxqlhAYcBdwCbgHXAMmx6vbUfDawCfgF8tuvc\nPwB+CuwEVgMLcjYBrgE2ANuAO4HRnP2d9rqv22v/JTCSs/8a8EN77Z8BH3ctu9fWdiFxoWoIdBhD\nqONzzygWkrlnNF21aLgKSd+hjYiMAHcB48CJwBLg08C51n408DDwGnAq8JXcufOA5cC1wK8CPwLu\nEpFOv3Yp8F+Ac4APAP8e+F+54v+n3fcBKwrnAxfZa+9r6/Uje+2/BG4WkV91LHu4qdpNH8ZufgtT\n12ujn9IAcwEDzMztuwFYaf/+FnDXJOd+Hngo9/lAYDuwyH7+HvBnOftvA28CBwD7A28AC3P2q4B/\ntn+fQtaL2S9n/yfgapeye21D0SOp2E0fxm6+MfGGZKkO9QjVIwGeAg40xuQzeN4E9heRg4EP20Zb\nxDHA2pxobSEbgswpsgOPAnsDs+22T4E9f+5PjTHbeth7lZ08UUONVSMnTUdeJiF2eNYldb1sHQYh\nGtRXSIwx48aYrZ3PIjKfbChyM9mQwQCniMhTIvITEbk0d/pBwOauS260+4vsG3P7O8d02yc7t6w9\naaL/uKp20yN086uKQAoN0qsOFYeJKeS2OId/ReQsEdkOPALcbYxZBcwg60GcBJwHXAH8mYh83J62\nV8GlTK7c7vJNbv9k54rjtfvZ0yayD6JqqDn0C4BBRKDCPQvWGH3qUCFBLwXxhEwEXLkPmA8cC3xV\nRJaSRVM2A2cbY3YA/yIi7wf+EPgaMMGeDVeAt+zf3Q27IxJvUSw2Qub0xeHa/ey7G0SWkDmSee97\n31t0SL3UkP05sngRVFxFrsr5u9GrAbqW4XnP9nj3p9MYobww+tThsBnF7/64DBND3LcAOD+djTFb\njTFPG2NuB75MFnF5hSwMnP8mT5JFWgC2AAd3XWo6WRi5yD7d/rvJ2iiwT3ZuWXv397vRGLPAGLNg\ndHS06JB6SdQH4UrpJ3wI4fS9ZyF7fz51qDJMbPp1A4tL+HehiKy1YeAO42S5GY+ROV2PztmOBJ63\nfz8BjOWudQBwOPB4kZ2st7OTLPfjJ2S9h257/twjRWR6D3uvstOmxaFGr+52COH0vWchG6PnyoLe\nw8RUHjj9wjrAIWQJY9eTRVIWAj8H/tjabwG+DxwHnEE21DnH2o4jE51LyKIlN5IltO1j7ReR9RBO\nJ3Pc/gD4eq7s24EfkyWenWLrscTa3gG8YMs/mqyH9AZwtEvZvbZUwr9Nr2rnvRKgR+JWk3OxhE40\nqzOUGzsxkMCZrWPAQ2TDhefInKp7Wds04Otk/pKfAZd0nXuu3b+TLAt1fs42AvwFWdbqNuDvgENy\n9kPJMmq3Aa8CV7N7Ru0Y8C/symz9T65l99pSEZKyhPxRVbmWb46JLu3pR8z75iokOrFRAW2dRT7k\nhD1VrtXGiYMmVt6b+UReeCUbFlx+YfrTG9aATmw0IJRyWoYc61e5Vgv9O62bIzUxVEgSprTTMqTj\nrcK12jgLulINFZKUKRuWDNkTqHgtfcIPFyokKVNyeOHaE3AZLqXWq0ghDTwEg/I99sDFIztsWypR\nmxjzX6QSoSi9HEUNdXapU+XJnBK492Ug4Nu/SlPEcFomMI9Iad9PDXV2qVPl91oSuPexUCFJmCjD\ni8Ap1V5d9bINKkCd+9bTpU5VhSCRdPYYqJAkTnCnZcDIjvcTumyDqlhnp3q61Mmx3pOKVirp7BFQ\nIRk2Qg6XfJ/QZRtU1Tq71NOlTg7H9BStFubXuKJCMmQEHS75dtVLNqjKdXapp0udXI7pIVoh732V\n6E+MyJGmyBeQUop8yqnbldLoa/xervV0qVO/Yyamn5j1RLoRYWTTD8J8nwprJ5c91zVFXoWkgFSE\npK7Ftn0bddOLgbtSZz3reM+ozveg9F2bQSCRsOdkpJa0Nhm11rMOP0iV6E+kyJH2SApIpkdSRze5\nhW/qpk7sYZv2SJRyeIQLG5niUNmN6O8ZVen1ROoxqZCkTMn/9MamOFRqpcpQLdYwT4c2BaQytIFy\n3WSfLm/TDtOUo1KKDm0GhlLdZI9hSpO5DamsydIGUn9rWHskBaTUIylDk45Tn55N6PoOau+myV6j\n9kiGkSZTsGteYa6bge7dtOCtYRWSAaLRvA7fFebK7O9FCst1xqIFkbUyS3YqLSDoMppl8Fl28vIL\ni7vsPj2oFJbrjEWVJT1rQnskCZD8E9GFuleY6yaF5Tpj0YK3hlVIGib22L4ukfIVhWDJWzUt19mE\n6LfiVQSX+RiHbatzztay87LGnuu0qdXuXOhXt9jLdbZxztWqoCvt+VNn+LfM+zRlw4Blw6tNJ6f1\nIlbdyly3zvB6KqFsDf+2hTJj+9hznUbwFwQbCkTyZZQaNtQUPWljKFuFpGnKjO1jz3UaYWLoYA0i\nYiN29tPU9V5SGxzAXaiQNEypJ2LsuU5DN5SQDSKFlwvrip60IG+kGxWSBHB+Isae6zR0QwnZIBII\ngdYWPUlBNMvi4pEFDgPuADYB64Bl7HpP5yLAdG335s49BXgc2Ak8CSzquvYlwIvAduBB4MicbQpw\nE7AZeA1YDkzN2Q8HHgB2AC8Bl3Zdu2fZk22prLRXROyoSsjrV10pcI+6XHx1shGlkKQUHcIxauMi\nIiPAGuB24CjgVOBV4Dxrvwq4C5iZ2w62tlFgK3CFPfcq4HVgprWfBmwDFgNzgW8Ca3JlfxF4BjgJ\n+HXgWeBLOfsPbdlzgd+3YnSmS9m9tpSFpE1UaRApNKYmQ+GphOFDCslc28uYmdt3A7DS/v03wPWT\nnPsJYF3uswDPA5+0n1cAy3P22basOfbzi8D5OfsFwHr79/vssbNy9luAW13K7rWpkITDt0HEWPe4\nDCkImSsxRcdVSFzetXkKONAYszW3701gf/v3TOD7k5x7DLC288EYY0RkLTAnZ78lZ39GRLYDc0Tk\nZeDd+fOBR4EZIjLdnrvVGLOuy36OY9lKDXi/+9O0w7GXozihjNJU3hXq62w1xoznRURE5pM11pvt\nrpnAx0Tk5yLyUxH5cxHZx9oOIvNv5Nlo9/ezd47Z3GUjZ/e9dtIMxLs3VWna4di0kLmSSKjYOWoj\nImfZ3sIjwN3GmFXW9H3gu8CZwGXAEjJnLMBeBZcyuXJ72Sez0cfucu09EJElIrJaRFZv2LCh6JBa\naCIZKUnhajpKU4OQBbnviQhemfDvfcB84GzgdBFZCmCM+ZQx5lJjzI+NMSuBzwP/2Z4zUVCGAG85\n2CcK6ij2347d99p7YIy50RizwBizYHR0tOiQevB4wlRdvjHFLMpQoVbvexNZyILd96Z7bhZnITHG\nbDXGPG2MuR34MrB0kkOfIAsXA2wBDu6yTycLI/ezb7GfD+6yQTZkqXLtdPF4G7XSDzKRrnERVd8M\nTnrxr1D3vemem6WvkIjIQhFZKyL5Y8eBnSLyHhH5NxE5NGebTZbTAZmoHN85V0QEmEeW29Gxj+XK\nOgLYD3jCGLMRWJ+3A8cCzxljtthzp4jIMV32/LV7lZ0mZZ8wVX+QAbrGPk/9WoZTFe9N1PVpAg1J\nUpliwKVH8iiZQ/U6EZktIgvJktBuN8Y8D/wM+GsRmSMivwX8CfC39tw7gQOAa0TkKLKcjoOBzquS\nK4CPiMh5VhCuAx42xjybs18mIieLyElkvpcVAMaYp8nyW74iIvNEZDHZsGuFY9lpUvYJU/UHWbFr\n7PPUr204lYj/oJCAQ5LoC3K51KHfAcaYXwKLgOPIHK1fI8swvdYe8rtkjs1/trZbyZK/MMa8AnwM\nOJ0sFHsW8FFjzKvW/k0ycbgG+FeykHInfAvwOeDbwLeA+4G/JxOEDott2avJRGiZMeZ+l7JTpfQT\npuoPsmrX2OepX9dwqib/gVfvKpEhSSh0PpIC2rQcRYh5OqrMfeGzPnEdaxpDPfOrVCkjlTlHeuE6\nH4kKSQFtEhJo9gfptbrfAE0QNOiLsOvERkNEvzFyVMemTxe9xm59dP9Byn6YGlEhGXBiOzZ9ogZ1\nRhqiR4cSyeNoGh3aFNC2oU0vBr3r3YvUfSSVy61hOKtDmwGh8hN1mLveNUSHmsjjSDEbWYUkYYL8\nYAag6+0tpjWJaO15HAlmI6uQpEyIH0zL8xUqiWliIhrMX5NgL1OFJGUC/GBSSaH2poqYJiSiQYcj\niQkkqJCkTaAfTAop1N5UENOkRDTkcCQhgeygQpIyCf5g+hE83FpRTJMR0YDDkaQEslOnxkpW+tK2\nfIso0YQWimkhgYcjyQhkpz6Nlq70pegHE/qpH0wAIkQTUnz6ejEogjgJmpBWQMoJaTESoEIlrfm+\njNeGl9dC0MbvqQlpg0qMHIJQ43eP7nuKyVVFhOgFpjYcCYkKSduIkUMQavzu031PMLmqm7aIXZOo\nkLSNGDkEgcbvXv6MBJOr9qAFYtc0KiRtI4LTLqRDs3T3vYIw1raMRoNil+RSIQW4rLSnJMTI4kXZ\nOh2BnXbeK+JV5fILi53HfYSx1hXmDptR7IyOnEmayip6LmjUpoCUozaDiE80o/ZZ1pqYKiCBKSBc\nozbaI1Eax6s3VONwo0wvMGiItw3+I4sKidJOah5uuIhd8KFIQ0MqH9TZqrSTik7nKE7M0NGdFmXD\nao9EaSVVnM7RnJiBhyKxHOsx0B5J4pR9cvo+aVMtpxfemaKx8kIi5Pi0JRtWhSRhymZU+mZgplpO\n0flJzzDWoqFIaDT8W0Aq4d+y4T/fcGGq5ex2bsAQbMywahtfzOuFvrQ3CJR9cvo+aVMtJ09LZhhr\ny1AkNCokKVN2zO07Rk+1nDzwU9lHAAAF8UlEQVQDPsNY21EhSZmyT07fJ22q5eQZ8BnG2o4KScKU\nfXL6PmlTLWc3htiR2QqMMX034DDgDmATsA5YhnXUdh33EPBC175TgMeBncCTwKIu+yXAi8B24EHg\nyJxtCnATsBl4DVgOTM3ZDwceAHYALwGXlil7sm1sbMwo6TF+2z1mfO4ZZnzaCdm/t93TdJUGHmC1\ncdGIvgdkvZY1wO3AUcCpwKvAeV3HnQtM5IUEGAW2AlfYc68CXgdmWvtpwDZgMTAX+CawJnf+F4Fn\ngJOAXweeBb6Us/8QuMue+/tWjM50KbvXpkKiKBkhhWQuYPINELgBWJn7fBDwMrCiS0g+AazLfRbg\neeCT9vMKYHnOPtuWNcd+fhE4P2e/AFhv/36fPXZWzn4LcKtL2b02FZLBQnsy/rgKiYuP5CngQGNM\nPvD+JrB/7vOVwD8B3+469xhgbeeDrdhaYM4k9mfIehVzRGQa8O68HXgUmCEi0+25W40x67rsk127\nu2xlCNBpEuuhr5AYY8aNMVs7n0VkPnAOcLP9fCxwPpmvo5uDyPwbeTba/f3snWM2d9nI2X2vrQwL\nOk1iLThHbUTkLBHZDjwC3G2MWWVNXwWuNsY8X3DaXgX7TK7cXvbJbPSxu1x7D0RkiYisFpHVGzZs\nKDpEaSMtmtOjzZQJ/94HzAfOBk4XkaUi8nFgBvClSc6ZKChDgLcc7BMFdRT7b8fue+09MMbcaIxZ\nYIxZMDo6WvhllBaS4ILbg4jzNAJ2ePM08LSIzAaWAvuQhWB/KSKd6+0rIluB3wG2AO/qutR0Mscs\n1n5wgX2TtdFln27/3dzn3M61e5WtDAOec8Iq5ejbIxGRhSKyVkTyx46T5WYsInNqzrfb5cAr9u/V\nwBPA8Z1zJVObeWS5HVj7WK6sI4D9gCeMMRuB9Xk7cCzwnDFmiz13iogc02XPX7tX2coQoOnwNdEv\nrAMcAmwAricLzy4Efg78ccGx57N7+HcGWS7HX5DlclxJllj2Tmv/j8AbwHlkgvQN4Pu5868lC9me\nTJZL8gzwhZx9NVmkaB5ZLsp24FSXsnttGv5VlAxC5ZFk12KMLGt1C/AcWZLXXgXH7SYkdt+pZL2D\nN8h6Ax/qsn+GLCt1B1mWaj4vZCpZdOg1u90EvCNnPwL4LrsyWy8uU/ZkmwqJomS4ConOR1JAKvOR\nKErT6HwkiqLUhgqJoiiVUSFRFKUy6iMpQEQ2kEWmFHcOBX7RdCUGiFTu568YY/pmaKqQKEEQkdUu\nTjnFjbbdTx3aKIpSGRUSRVEqo0KihOLGpiswYLTqfqqPRFGUymiPRFGUyqiQDCEicpCI3CwivxCR\nl0TkiyKyj7UdLiIPiMgOa7u069xTRORxEdkpIk+KyKIu+yUi8qKIbBeRB0XkyJxtiojcJCKbReQ1\nEVkuIlNz9p5lp4KIvFNEPiMiz4jI3rn9yd67fmVXxuWFHN0GayN7+fHHwK8BHwL+DfgTa/OemZ+I\nqwKkstnvsJ1sugwD7O1S/ybvXb+yg9yXpv9jdKt/I0t0+r3c5z8FHqbizPxEXBUglQ34HNm0Fgvz\nQpLyvetXdohNhzbDyX5kE1N12Gb3VZ2ZP+aqAElgjPkfxph/LDClfO+ir6igQjKcrAL+m4hMF5H3\nkD2xVlJ9Zv6YqwKkTsr3Lvq9VSEZTj5FNinUq2QTVb0KXEP1mfljrgqQOinfu+j3ti3/SUpYbiJz\n3H0Q+G1gGtlUlFVn5o+5KkDqpHzvot9b51nklcFARP4D8FHg8M6YWkT+CLgH+EOqzcwfc1WA1Km6\nqkGrV1TQHsnwsa/9N7/83Dayh8pjVJuZP+aqAKlTdVWDdq+o0HQ4Tbd6NzLBeAr4P8DRwPHAPwDf\nsXbvmfmJuCpAahtd4d+U712/soPcj6b/Q3SrfwOOtD/UjWRLjfwt8O+srdLM/ERcFSClbRIhSfbe\n9Su76qYv7SmKUhn1kSiKUhkVEkVRKqNCoihKZVRIFEWpjAqJoiiVUSFRFKUyKiSKolRGhURRlMqo\nkCiKUpn/D+I8N3Mqsq90AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f618484d8d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AreaKey</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>Longitud</th>\n",
+       "      <th>TotPop90</th>\n",
+       "      <th>PctRural</th>\n",
+       "      <th>PctBach</th>\n",
+       "      <th>PctEld</th>\n",
+       "      <th>PctFB</th>\n",
+       "      <th>PctPov</th>\n",
+       "      <th>PctBlack</th>\n",
+       "      <th>ID</th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>13001</td>\n",
+       "      <td>31.75339</td>\n",
+       "      <td>-82.28558</td>\n",
+       "      <td>15744</td>\n",
+       "      <td>75.6</td>\n",
+       "      <td>8.2</td>\n",
+       "      <td>11.43</td>\n",
+       "      <td>0.64</td>\n",
+       "      <td>19.9</td>\n",
+       "      <td>20.76</td>\n",
+       "      <td>133</td>\n",
+       "      <td>941396.6</td>\n",
+       "      <td>3521764.0</td>\n",
+       "      <td>POINT (941396.6 3521764)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>13003</td>\n",
+       "      <td>31.29486</td>\n",
+       "      <td>-82.87474</td>\n",
+       "      <td>6213</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>6.4</td>\n",
+       "      <td>11.77</td>\n",
+       "      <td>1.58</td>\n",
+       "      <td>26.0</td>\n",
+       "      <td>26.86</td>\n",
+       "      <td>158</td>\n",
+       "      <td>895553.0</td>\n",
+       "      <td>3471916.0</td>\n",
+       "      <td>POINT (895553 3471916)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>13005</td>\n",
+       "      <td>31.55678</td>\n",
+       "      <td>-82.45115</td>\n",
+       "      <td>9566</td>\n",
+       "      <td>61.7</td>\n",
+       "      <td>6.6</td>\n",
+       "      <td>11.11</td>\n",
+       "      <td>0.27</td>\n",
+       "      <td>24.1</td>\n",
+       "      <td>15.42</td>\n",
+       "      <td>146</td>\n",
+       "      <td>930946.4</td>\n",
+       "      <td>3502787.0</td>\n",
+       "      <td>POINT (930946.4 3502787)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>13007</td>\n",
+       "      <td>31.33084</td>\n",
+       "      <td>-84.45401</td>\n",
+       "      <td>3615</td>\n",
+       "      <td>100.0</td>\n",
+       "      <td>9.4</td>\n",
+       "      <td>13.17</td>\n",
+       "      <td>0.11</td>\n",
+       "      <td>24.8</td>\n",
+       "      <td>51.67</td>\n",
+       "      <td>155</td>\n",
+       "      <td>745398.6</td>\n",
+       "      <td>3474765.0</td>\n",
+       "      <td>POINT (745398.6 3474765)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>13009</td>\n",
+       "      <td>33.07193</td>\n",
+       "      <td>-83.25085</td>\n",
+       "      <td>39530</td>\n",
+       "      <td>42.7</td>\n",
+       "      <td>13.3</td>\n",
+       "      <td>8.64</td>\n",
+       "      <td>1.43</td>\n",
+       "      <td>17.5</td>\n",
+       "      <td>42.39</td>\n",
+       "      <td>79</td>\n",
+       "      <td>849431.3</td>\n",
+       "      <td>3665553.0</td>\n",
+       "      <td>POINT (849431.3 3665553)</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   AreaKey  Latitude  Longitud  TotPop90  PctRural  PctBach  PctEld  PctFB  \\\n",
+       "0    13001  31.75339 -82.28558     15744      75.6      8.2   11.43   0.64   \n",
+       "1    13003  31.29486 -82.87474      6213     100.0      6.4   11.77   1.58   \n",
+       "2    13005  31.55678 -82.45115      9566      61.7      6.6   11.11   0.27   \n",
+       "3    13007  31.33084 -84.45401      3615     100.0      9.4   13.17   0.11   \n",
+       "4    13009  33.07193 -83.25085     39530      42.7     13.3    8.64   1.43   \n",
+       "\n",
+       "   PctPov  PctBlack   ID         X          Y                  geometry  \n",
+       "0    19.9     20.76  133  941396.6  3521764.0  POINT (941396.6 3521764)  \n",
+       "1    26.0     26.86  158  895553.0  3471916.0    POINT (895553 3471916)  \n",
+       "2    24.1     15.42  146  930946.4  3502787.0  POINT (930946.4 3502787)  \n",
+       "3    24.8     51.67  155  745398.6  3474765.0  POINT (745398.6 3474765)  \n",
+       "4    17.5     42.39   79  849431.3  3665553.0  POINT (849431.3 3665553)  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "X = data[['PctFB', 'PctPov', 'PctBlack']].values\n",
+    "Y = data[['PctBach']].values\n",
+    "coords = data[['X','Y']].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "N = Y.shape[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'mgwr' from '/home/lw17329/Dropbox/dev/gwr/mgwr/__init__.py'>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import imp\n",
+    "import mgwr\n",
+    "imp.reload(mgwr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 48%|████▊     | 97/200 [05:10<05:29,  3.20s/it]"
+     ]
+    }
+   ],
+   "source": [
+    "sb = mgwr.sel_bw.Sel_BW(coords, Y, X, multi=True, fixed=True)\n",
+    "out = sb.search(search='scipy', tol=1e-2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'scipy'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb.search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from collections import namedtuple"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "partials = sb.bw.partial_models_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "test = partials[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "hats = [m.S for m in partials]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(159, 4)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sb.bw.partial_predictions.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "fullmod = mgwr.gwr.MGWR(coords, Y, X, out, sb.bw.partial_predictions, sb.bw.model_residuals_).fit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7f6135cf1e80>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEACAYAAABI5zaHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAGa9JREFUeJzt3X+sXOV54PHvM8bEFgEMiRvvCgdo\naZUgUFDixGmRdlGVRdaSkiIUt6FNNtsqpHFbtklQ6FLJTRyJiO7mF0vdLN2QSE2zYMWiSTfKLWra\n7A+kTXpRNjQQ0LYLiSk1oTIGAzYYz7t/nJl75947P87MnLlz5p3vR7IuPjN35j0MPPOe533e50RK\nCUlSXhrTHoAkqXoGd0nKkMFdkjJkcJekDBncJSlDBndJypDBXZIyZHCXpAwZ3CUpQ6dN641f/epX\npwsuuGBaby9JM+n+++//p5TS1kHPm1pwv+CCC1hcXJzW20vSTIqIH5Z5nmkZScqQwV2SMmRwl6QM\nGdwlKUMGd0nKkMFdqpnmgQWal1xNc8vO4ueBhWkPSTNoaqWQktZqHliAG26B4yeKA4cOww230AQa\nu3dNdWyaLc7cpTrZt385sLcdP1Ecl4ZgcJfq5PEnhzsu9WBwl+rkvNcMd1zqweAu1cnePbB508pj\nmzcVx6UhuKAq1Uhj9y6aUOTYH3+ymLHv3eNiqoZmcJdqprF7FxjMNSbTMpKUIYO7JGXI4C5JGTK4\nS1KGDO6SlCGDuyRlyOAuSRkyuEtShgzukpQhg7skZcjgLkkZMrhLUoYM7pKUIYO7JGXI4C5JGTK4\nS1KGDO6SlCGDuyRlyOAuSRkyuEs11jywQPOSq2lu2Vn8PLAw7SFpRniDbKmmmgcW4IZb4PiJ4sCh\nw3DDLTRp3URb6sOZu1RX+/YvB/a24yeK45o5630V5sxdqqvHnxzuuGprGldhztylujrvNcMdV31N\n4SrM4C7V1d49sHnTymObNxXHNVumcBVmcJdqqrF7F9x2M2zfBhHFz9tudjF1Fk3hKsycu1Rjjd27\nwGA++/buWZlzh4lfhTlzl2rMOvc8TOMqzJm7VFPWuedlva/CnLlLdWWdu8ZgcJfqyjp3jcHgLtWV\nde4ag8Fdqivr3DUGF1Slmmrs3kUTihz7408WM/a9e1xMVSkGd6nGrHPXqEqlZSLivIi4JyKORsRj\nEXFzRETrsTdGxHci4sWIeDQi3jPZIUuSBhkY3COiAXwVOAXsBK4HPgz8akSc3nrs/wBvAD4J3BkR\nb5jYiCVJA5VJy7weeCNwVUrpMPBIRNwN/AJwGHgV8DsppReAhyPil4F3Ad+b0JglSQOUCe4PA2em\nlJ7rOHYSOAO4GPj7VmBvewB4XXVDlCQNa2BaJqV0qjOwR8RlwHXAncBZwDOrfuXp1nFJc8Q+OPVS\nus49Iq6NiOPAd4E/TykdBDZ0eWrq9boRcX1ELEbE4lNPPTXSgCXVz1IfnEOHIaXlPjgG+KkZZhPT\nXwCXAe8EroqID0DRw2jV8wJ4udsLpJTuSCntSCnt2Lp16yjjlVRH9sGpndJ17q3UzCMUC6oXAR8A\nvgCcs+qpW4CjlY1QUv3ZB6d2ypRCXhERf9sqiWw7BbwIPAT8VERs6XjsUuDBaocpqdbsg1M7ZdIy\nDwDbgM9ExEURcQXwW8BXgG8BPwZuj4jXt1I1bwXumsxwJdWSfXBqZ2BaJqV0JCJ2UWxQ+i5FNcwX\ngP+YUjoVEe8APkexkekJ4N+klH4wwTFLqhn74NRPpJSm8sY7duxIi4uLU3nvWdI8sOD/MJKWRMT9\nKaUdg55n47Aa8zZrkkZlP/c6s7xM0ogM7nVmeZmkERnc68zyMkkjMrjXmeVlkkbkgmqNWV4maVQG\n95rzNmuSRmFaRpIyZHCXpAwZ3CUpQwZ3ScqQwV2SMmRwl6QMGdwlKUMGd0nKkMFdWWoeWKB5ydU0\nt+wsfh5YmPaQpHXlDlVlxz74kjN35cg++JLBXRmyD75kcFeG7IMvGdyVIfvgSy6oKj/2wZcM7sqU\nffA170zLSFKGDO6SlCGDuyRlyOAujclWB6ojF1SlMdjqQHXlzF0ah60OVFMGd2kctjpQTRncpXHY\n6kA1ZXCXxmGrA9WUC6rSGGx1oLoyuEtjstWB6si0jCRlyOAuSRkyuEtShgzukpQhg7skZcjgLkkZ\nMrhLUoYM7pKUIYO7JGXI4C5JGTK4S1KGDO6SlCGDuyRlqFRwj4jzI+LPIuJIRPxDRHwqIl7ReuzC\niPhmRJyIiCci4iOTHbIkaZCBwT0iNgLfAF4CLgfeDVwH3Nx6yt3Ac8CbgA8BH4uIqycyWknZah5Y\noHnJ1TS37Cx+HliY9pBmWpl+7j8L/AywM6V0DPhBRNwOXBMRXwLeDFyYUnoMeDAi3k4R/L82oTFL\nykzzwALccMvyzcYPHYYbbqEJ3vhkRGXSMo8Cv9gK7G0vAieBi4HnWoG97QHgdZWNsOYmOdtwJqO5\nsW//cmBvO36iOK6RDJy5p5QOAYfaf4+IBvArwJ8CZwHPrPqVp1vHszfJ2YYzGc2Vx58c7rgGGqVa\n5ncpgvftwIYuj6derxsR10fEYkQsPvXUUyO8dc1McrbhTEbz5LzXDHdcAw0V3CPiSuD3gN0ppeNQ\nTCRXPw14udvvp5TuSCntSCnt2Lp16yjjrZdJzjacyWie7N0DmzetPLZ5U3FcIykd3CPiIuAu4P0p\npcXW4WPAOaueugU4Ws3wam6Ssw1nMpojjd274LabYfs2iCh+3nazKcgxlK1zPxP4KvBHKaUvdTz0\nELApIi7uOHYp8GB1Q6yxSc42nMlozjR276Lx/a/ROPrt4qeBfSwDF1QjIoA/AZ4Ebo+IbR0P/wi4\nH/hsRHyQonrmncA7JjDW2mns3kUTijz4408Ws+q9eyr5j3KSry0pf5FS6v+EiPOBx3o8/G+B/wH8\nF+DngCPAf0gpfXrQG+/YsSMtLi4OeprWUfPAgl8mUs1FxP0ppR2DnlemFPKHFIuk/fx82YGpniy9\nlPJSZoeqMrRmlv78C71LLw3u0syxK+QcWpqlHzoMKRU/jzzb/clDlF66o1aqD2fu86jbBqleSpZe\nmtaR6sWZ+zwqOxsfpvTSHbVSrRjc51Gv2fi5Z4++icQdtVKtmJaZR3v3rEyhQDFLv/XDo6dQzntN\nkYrpdlzSunPmPocmstW7hjtqXeDVPHPmPqcau3dVWuJYtx21LvBq3jlzr1DVM8VZm3nWqjeIC7ya\nc87cK1L1TNGZ55hc4NWcc+Zelapnis48S+t6hWPLZM05g3tVqp4pOvMspetu2xtugSsvr90Cr7Se\nDO5VGXGm2DOv7syznF5XOPfe580fNNfMuVelV+14n5liv7z6KK83l/pc4VRdESTNEmfuJZSpWhmp\ndrxPXn0WbjtWi2oer3CkrgberGNSZuVmHWtm11DMoCsItM0tO4s88WoRNI5+e6zXnrRJ/nuZxXFI\n66XszTqcuQ8yyaqVEWadtZgtQ22qeWbhCkeaBoP7IJOsWhlyy36vypCpBPgaVfPUavNUTdVmUqB1\nY3AfZII53aFnnTWZLQPmumdIrSYFWjcG90Em3BBrqFnngNnyus7OatgoTD3UaVKgdWNwH6BWOd0+\ns+X1np3V6t+L+qtRCk3rx2qZGdKvMoR9+7v3U9++jcb3v7Z+g1TtNC+52v82MmK1TIb6zpadnc2V\noVJwptDmkjtUZ0zPXZfeCWluDNsxtG699rU+TMtkws0888M0y3wrm5Zx5p4JZ2dzxBScSjC4Z6Rs\no6zmgQW/BGaZKTiV4IJqRaqoMV+POnU3tGTABVKVYM69AuPmu5sHFuCmT8KRZ7o/YUMD3nsNjU/d\nNP5Yzddmwauv+WUpZEVKzabH2AG49MXQK7ADnGrC5w/S/NCtQ46+i1552W4BPyO59Vaxn44GMbj3\nUTqFMeICV/PAAvzGR9d+MfTyxXvKPa/f+zWi+4PBzAe8XkxFaR4Z3PspOyMfsXUvN9xSzMrLGua5\nw75fIt9eI/ZW0RwyuPdTdkY+ygJXt4AzSK9Zdxll3i/XUjpLBzWHDO79lJyRr2gLAMUCaGtm2PPS\nf5TAEjF6KqHM++VaSmd7Ys0hg3s/Q8zIG7t3LT+/nfrol9sdFFjO2Lz22Knm6KmEQe+XcymdpYOa\nQwb3PiZ6M429e6BXlmX7NnihRwpl1FRCtwDXfv/M2/XanljzyDr3Cg17w+vmh26FOw8Wi5ltE2zh\na220NPvsLTMNQ24Lb3zqJppvfUPXgNuE7hujxkgllG1PIGn2mZYpofQGmG6pj9M3wpGjNM9+S/Hn\nwn+14vd7bUYZJ5UwCxt2qh7jLJyztJ5MywzQtbVAAL92bdd2ACtSH+ecBUefhWaPf8fbt1WeGplk\n69+q0jpVj9F2x5onZdMyBvcBevZiCeCOfX2DR8/f7bR5E1x3Fdx7XyW58En1jqkygFY9RvvlaJ7Y\nW6YqvapTyuzoLFPZcvxEsag6YGt86bTDpDbsVLnLs+oxuklJWiPr4F5JHrZfffigWXnZTTKrL55W\nBc2heqNMasNOlQG06jG6SUlaI9vgXlmzqAHVKX2/OPbugY0jFiR1Bs1h6+cnsWGnygBa9RjdpCSt\nkW1wryqNMDCf3OeLo7F7F+zfC+eeNdR7tl936UtjiFnzxDbsVBhAqx6jm5SktbJdUB12Q1Hf1yqz\nMAp9F/D6vkawNjVT5vF1XjB0E5Q0fS6oTjqN0E2//HO/xxLLTcd6Pd7NlZcPHlOFvEGENDtKBfeI\neFVE3BgRfxcRp3UcvzAivhkRJyLiiYj4yOSGOqSSaYQ1i64funXNIuyaro+99Pvi6PdYewYeQ7b0\nvfe+4Z4vaW4MXO2LiD8Afht4FviJVQ/fDfwj8CbgUuALEfFwSmnqxcVLW/j7pBHW1G4fOgyfP7j8\nIu1ceufr/ebH4aWTa99wUP557x7Ysw9Ovrzy+Okbl3+vV/uCXiz1k9RDmZn7MeBK4Jc6D0bETwNv\nBv5dSunBlNJdwEHguspHOYTmgQWaF76N5tlvgfftheePwx0f655GKHMDi85F2Js+2T2wA1x31ZrX\n77wqYN9+eM871i6uvrKjtW/Z9E/bGKV+bteX8jZw5p5S+jhARFyx6qGLgedSSo91HHuAKQb35oGF\ntbPjI8/Ab358afa9QtmZb/t5/W5ifedBmp8/uNRSAFh7VfDlrxe7Ub/89eXjR55de3Vw0yf7vxcU\nJZYjlvp1vWLpGIOk2Ve6WqYV3P8a2JhSejki3g18IqV0Xsdz3gf8+5TSTw56vUlUy/StSOlSWVK6\nCqb1+6Wfu/E0OHWqe0+ZDY3u9zFdNb6VPWrOhBdPFlchUMz+b72xdi0KJE3eerT83dDlWKJPqici\nrgeuB3jta187xlv30G8mfuhwEdTa+fcrL18OlmUMkwtfnVfv1OsG1avGPtH2vG7Xl7I3Tilks8vv\nB9AzsqWU7kgp7Ugp7di6desYb90xiM68dr8bSAcrd6t+/uDg1Md6Ws+t8m7Xl7I3TnA/Bpyz6tgW\n4OgYrzmUNS0Ges2Kof8moWkL1nervNv1peyNE9wfAjZFxMUdxy4FHhxvSEPoVe3SOYM/9+xq3/OM\nzcv17sPWpfeSgOt/f92qVtyuL+Vv5Jx7SumRiLgf+GxEfJCieuadwDuqGtxAfdrxNp75ztJfh1o4\nHeSlk8sz3Ov3VvOasLJHDZOvWvGWe1Lexm0/sJtiYXUR+Axwc0rp3rFHVVbZ3PHePUXqowonXy5K\nFX/jo5NJ9YzaI12SOpQO7imlb6WUIqX0csex/5dS+vmU0qaU0j9PKX16MsNcqb2I2nU23qX+u7F7\nV7WB+Mgz/fP747JqRdKYZq5x2IpF1G565cEH9YWZpA2N4dr+WrUiaUwzF9wHtgx46WT5m1ish82b\n4HMfhVtv7P7+q7+MrFqRVIHZC+5lUha9ntOvDr5KGxrdq1A2v2L5OeeeBX+8D+74mFUrkio3zg7V\n6SjTOXFVWmNNL5VJCuBzH+3ffRLg+EuAVStV84YiUmH2Zu6DUhYdaY2lhdf37V2/wP5r15brPmlV\nTOUqu2+ulIGZmrkvzcp62dBYSmus62y97V+8Ge69r2g33G4Q1q/hmFUx1er3JersXXNmZoL7wGC9\nedPKfHWZXu1V++9/s/zP7VLJQ4d73wPVqphq2RBNWjI7aZl+wXr7tqJP+r79SzefqGxH6mqjLMom\n1m6iOn0jPP+CN8uokg3RpCWzE9x7zb4iihz7l7++Mtc6icKY7du692gvo30T7Iii301KxY06zA1X\nx4Zo0pLZCe79ZmXdZvXdZsubNxXlh/02NJ3RpxZ+nKuBDY3lCg7S2p7vLrCOzYZo0rKZybmzd0/3\nnPvzLxQz4G7as+VVZXFNKJp+dZuEn7sFXnG8+l7vnTn4XswNj83SUqkwMzP3pVnZ6ha+vQI7LN02\nrnH02ytukN2318zjT8I1bxt+gNu3wa9fu3xVsKGx8mcZrauTcW9e7c2vJc3OzJ3WDaT37S83q+6R\nax1YTnnOWfDFe4YbWI97jzYPLBQ19mW0xjvuzau9+bUkmKGZ+5KyqYvrrloTzAY2HYPhOz72+xK5\n4Zbev3fu2d1zw+NueHLDlCRmbOYOlGs/AHDvfWuPVVX73q5b376t9/b2fu+1eRPc+uHuvzdurba1\n3pKYxeDea2F1tUOHl+vd27tFx1EmoHfqF0z7VXD0+vIqW6s97u9LysLMpWVWlLv1EywHuXED+4YG\n3LGPxjPfWbEw21evYLp9W//f79Wa+Pnj5RZGrfWWxAwGdygCfOP7Xyvuk/rr166tZ++13X8UmzfB\ne69Zsfu1V5DtrFLh+ePFXaFWv9aAILtcFbTq5h5Hnim10clab0kAkdIkbgQ62I4dO9Li4mIlr7Wm\nzWuVrQfO2FxsOHrp5PKx1X1s6NH75vSN8MrN8PSxodvP9myh0KMyR9J8iIj7U0o7Bj4vh+C+2kR7\ny7StCrJVB+Pmlp1Fa4JuIuxVLs2pssF9JtMyA63HLfVWL5hWXaXSbwHUfjSSBsgyuK9ZdG3vEj33\nrCJVUoXVwbfqjoRlvqCsX5fUQ5bBHVYuujaO/O/i56N/Ce++evwX77YwOmaVyuqWAcDKhdFerF+X\n1EW2wb2ne/5y+N/ZeFqxo7RP9ck4VSq9bg8HLPXG6Vn6af26pC6yXFDtp3n2W8o9sUs3yYmNqcRi\nbNdqnC5VO5LyVnZBdfZ2qK6H1TXmk1ZiMXapVXFnyafVMpJ6mL/gfu5Z/dsEbzwNnju+/Jz16KpY\nsmWAvcollTV/Ofdbb1y7c7Rt+zY484yVG5Zg8lUptgyQVLG5C+6N3btg/96VC59/vNw3hqd7zOon\nWJViywBJVZu7BdVB3PYvqc7me4fqOEyRSMrA/C2oDmBViqQcGNy7sCpF0qwzLSNJGTK4S1KGDO6S\nlCGDuyRlyOAuSRma2iamiHgK+OFU3nx9vBr4p2kPYh3Mw3nOwznCfJxnDud4fkpp66AnTS245y4i\nFsvsIpt183Ce83COMB/nOQ/n2GZaRpIyZHCXpAwZ3CfnjmkPYJ3Mw3nOwznCfJznPJwjYM5dkrLk\nzF2SMmRwH1NEvCoiboyIv4uI0zqOXxgR34yIExHxRER8ZJrjHFef83x7RKRVfx6e5lhHFRHnR8Sf\nRcSRiPiHiPhURLyi9Vg2n+eA88zi84yI8yLinog4GhGPRcTNERGtx94YEd+JiBcj4tGIeM+0xzsJ\ndoUcQ0T8AfDbwLPAT6x6+G7gH4E3AZcCX4iIh1NKM3fHjwHnuQ34LvCvO469vE5Dq0xEbAS+AXwf\nuBz4Z8CXgWPA75PJ51niPGf+84yIBvBV4FFgJ3A+8F+BQxFxd+uxbwDvAd4G3BkR30spfW9KQ54I\ng/t4jgFXAhuAv24fjIifBt4MXJhSegx4MCLeDlwHzFQwaOl6ni3bgMdTSl1uXzVTfhb4GWBnSukY\n8IOIuB24JiK+RD6fZ8/zZDm4z/rn+XrgjcBVrfN4pBXUfwE4DLwK+J2U0gvAwxHxy8C7gKyCu2mZ\nMaSUPp5S+p9dHroYeK4VCNoeAF63LgOrWJ/zhCIYzHIgaHsU+MVWwGt7EThJXp9nv/OEPD7Ph4Ez\nV31BnQTOoPgs/74V2Ntm9bPsy+A+GWcBz6w69nTreG62AT8XEf83In4UEf85Il457UENK6V0KKX0\n39p/b13a/wpwkIw+zwHnCRl8nimlUyml59p/j4jLKK6y7iSjz3IQg/tkbOhyLJHnv+/7gfuAXwLe\nT5G++U9THVE1fpfif/jbyfvz7DxPyOjzjIhrI+I4xRrCn6eUDpL3Z7mCOffJaLL2P5Zgxhamykgp\nfaLz7xHxYeCuiHhfSmkmzzcirgR+D/iXKaXjEZHl57n6PCG7z/MvgMsoFsD/MCI+wBz9v5ndt1VN\nHAPOWXVsC3B0CmNZbw8BG1lbVTMTIuIi4C7g/Smlxdbh7D7PHufZzcx+niml51JKj6SUvgJ8GvgA\nGX6WvRjcJ+MhYFNEXNxx7FLgwSmNZyIi4vRWnfRlHYcvopgF/XhKwxpZRJxJUSb3RymlL3U8lNXn\n2es8c/k8I+KKiPjb1npC2ymKheOHgJ+KiC0dj83sZ9mPwX0CUkqPUOQuPxsRl0TEbuCdwJ9Od2TV\nSim9BPwv4LaIeENEvAX4BHDXrF3Ctza4/AnwJHB7RGxr/wF+RCaf54Dz3EAen+cDFAvDn4mIiyLi\nCuC3gK8A36L4oro9Il7fStW8leIqJi8pJf+M+Qe4gmJR5rSOYz8J/BVwAngC+OC0xzmh8zwH+CLF\nDRB+TFGRcPa0xzrCuZ3fOrduf96by+dZ4jxz+TzfRBHIj1F8OX8M2NDx2N9QzOQfBd417fFO4o+N\nwyQpQ6ZlJClDBndJypDBXZIyZHCXpAwZ3CUpQwZ3ScqQwV2SMmRwl6QMGdwlKUP/Hwsn6XHwd7Ee\nAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f613658f6d8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(fullmod.predy.sum(axis=1), Y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7f6135cb13c8>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEACAYAAABI5zaHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAGHVJREFUeJzt3X+sXGWdx/H3Zy7FViy2YOVqyq+1\nGiCwNHC1KiZ2zW7TCIrKctXq+jMW6SKrSERrUn/tSjAui9hFJS6YFd1yI0Eqhqu7/kjUzaq3iyLU\nEn8UaMWWuqVQtGDb+e4fZ247nTtz58ydM3dmnvm8kkl7n3M68xwO/fSZ73nOcxQRmJlZWkrd7oCZ\nmRXP4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXoqG598LOe9aw45ZRT\nuvXxZmZ9adOmTX+IiEXN9utauJ9yyilMTEx06+PNzPqSpAfz7OeyjJlZghzuZmYJcribmSXI4W5m\nlqBc4S5psaTbJe2R9ICktZJU2XaZpKh5jXe222ZmNp2m4S6pBNwBHASWAauB9wNvruwyDGwEnlP1\nemMnOmtm1q/KY+OUz3w15QXLsl/HOjsGzjMV8nTgHOD8iNgB3C/pVuBVwJfJwv3ByjYzM6tRHhuH\nyz8J+57MGrbtgMs/SRkoja7syGfmKctsAebXhPd+4JjK74cBB7uZWSMfv+FwsE/a92TW3iFNwz0i\nDkbEE5M/S1oKrAJuqjQNA6+T9KCk30i6WtKcznTXzKwPbd/ZWnsBcs+WkXSRpH3A3cA3IuK2yqb/\nBr4LvBr4EFlNfm2D91gtaULSxK5du9rruZlZv1h8QmvtBWhlKuS3gKXAxcD5ki4FiIjLI+IDEfHz\niBgD/gl4a703iIgbI2IkIkYWLWq6NIKZWRrWrYF5c49smzc3a++Q3GvLVEoz95NdUF0CXAp8rs6u\nm4HFxXTPzKz/lUZXUoasxr59ZzZiX7emYxdTIUe4S1oOfBY4OyLKleaDwFOSTgQ2AWdExB8q25YA\nD3egr2Zmfas0uhI6GOZTPi/HPveQXTS9TtKSSthfBnwtIrYBW4HPSzpN0iuAD5JNkTQzsy7JM1tm\nN7AS+Euyi6n/DnwJ+HRll78FhoD/qWzbAPxjB/pqZmY55aq5R8QmYHmDbduA1xbYJzMza5MXDjMz\nS5DD3cwsQQ53M7MEOdzNzBLkcDczS5DD3cwsQQ53M7MEOdzNzBLkcDczS5DD3cwsQQ53M7MEOdzN\nzBLkcDczS5DD3cwsQQ53M7MEOdzNzBLkcDczS5DD3cwsQQ53M7MEOdzNzBLkcDczS5DD3cwsQQ53\nM7ME5Qp3SYsl3S5pj6QHJK2VpMq2cyT9RNJTkrZKektnu2xmZs00DXdJJeAO4CCwDFgNvB94s6Sj\nK9t+BpwN/DNwk6SzO9ZjMzNr6qgc+5wOnAOcHxE7gPsl3Qq8CtgBHA+8NyL+BGyR9AbgjcDPO9Rn\nMzNrIk+4bwHmR8QTVW37gWOAM4DfVIJ90j3AacV10czMWtW0LBMRB6uDXdJSYBVwE3As8FjNH3m0\n0m5mZl2Se7aMpIsk7QPuBr4REbcBQ3V2jUbvK2m1pAlJE7t27ZpRh83MrLlWpkJ+C1gKXAycL+lS\noFznPQQcqPcGEXFjRIxExMiiRYtm0l8zM8shT80dgEpp5n6yC6pLgEuBm4GFNbsuAPYU1kMzM2tZ\nnqmQyyX9ojIlctJB4ClgM/A8SQuqtp0F3FdsN83MrBV5yjL3AMPAdZKWSFoOXAZ8Dfg+8AiwXtLp\nlVLNi4ENnemumZnl0bQsExG7Ja0ku0HpbrLZMDcDn46Ig5IuBD5PdiPTw8BbI+KXHeyzmZk1kavm\nHhGbgOXTbHthgX0yM7M2eeEwMytEeWyc8pmvprxgWfbr2Hi3uzTQcs+WMTNrpDw2Dpd/EvY9mTVs\n2wGXfzKbKz26sqt9G1QeuZtZ+z5+w+Fgn7TvyazdusLhbmbt276ztXbrOIe7mbVv8QmttVvHOdzN\nrH3r1sC8uUe2zZubtVtX+IKqmbWtNLqSMmQ19u07sxH7ujW+mNpFDnczK0RpdCU4zHuGyzJmZgly\nuJuZJcjhbmaWIIe7mVmCHO5mZglyuJuZJcjhbmaWIIe7mVmCHO5mZglyuJuZJcjhbjYg/KSkweK1\nZcwGgJ+UNHg8cjcbBH5S0sBxuJsNAj8paeA43M0GgZ+UNHByhbukkyV9XdJuSb+TdK2kp1W2XSAp\nal5bOtttM2uJn5Q0cJqGu6Q5wF3An4HzgL8DVgFrK7sMA3cDz6l6vawTnTWzmSmNroTr18KJwyBl\nv16/tqcupno2T7HyzJZ5CfACYFlE7AV+KWk98FrgI2Thvj0idnSum2bWrl5+UpJn8xQvT1lmK/Ca\nSrBPegrYX/n9MOBgN7OZ82yewjUN94jYFhF3Tv4sqQS8Cbit0jQMvFTSryQ9JOkLkp7Rme6aGSRY\nwvBsnsLN5CamDwLHAusrP28C/g/4AnACcAPwWeDttX9Q0mpgNcBJJ500g482GzzlsfFsBLt9Zza7\nZcV58NVvplXCWHxCdhz12m1GFBH5d5ZWALcDL4+IiQb7vA7YADw9Ig40eq+RkZGYmKj7FmZWMaUW\nDSCg3l/bE4cp3btxtrpWqLrHOW9uz1307QWSNkXESLP9cs9zl7SELLQvaRTsFZuBOcCz8763mTVQ\nrxbdaDzWxyWMfpjN029ylWUkzQfuAD4XEbdUtR9NdsH1/Ij4WaV5CXAAeKTgvpoNhCPKMC18s+73\nEkYvz+bpR03DXZKALwM7gfWShqs2Pwb8ELhe0nuApwFXAxumK8mYWX11yxP11JZmfEOS1chTljkJ\nuBD4K+Bh4PdVr9cD7wZ+C3wHuBP4KXBZJzprlrx6ZZhaAt5xkUsYNq2mI/eIeJDsf6fpvK2Q3pgN\nujx184DStVd1vi/W17xwmFkvyVM3P3G4+T428BzuZr2k3gJf1Vxbt5z8JCazHlIaXUkZDs+WWTgf\nEDz6eDaqX7fGtXXLxeFu1mM8JdCK4LKMmVmCHO5mbUpuES9LgssyZm3wOuTWqzxyN2uH1yG3HuVw\nN2uH1yG3HuVwN2tHo5uO+nwRL+t/DnezdtS76cg3GlkP8AVVszZMuenINxpZj3C4m7XJNx1ZL3JZ\nxswsQQ53M7MEOdzNzBLkcDczS5DD3cwsQQ53M7MEOdzNzBLkcDczS5DD3cwsQQ53M7ME5Qp3SSdL\n+rqk3ZJ+J+laSU+rbDtV0nckPSnpYUkf6GyXzcysmaZry0iaA9wF3AucBzwH+CqwF/gIcCvwe+Bc\n4CzgZklbImJjpzptZmbTyzNyfwnwAuCdEfHLiPgusB64QNLzgRcC/xAR90XEBuA2YFXHemyWk59t\naoMsT7hvBV4TEXur2p4C9gNnAE9ExANV2+4BTiush2YzcOjZptt2QMThZ5s64G1ANA33iNgWEXdO\n/iypBLyJbIR+LPBYzR95tNJu1j1+tqkNuJnMlvkgWXivB4bqbI9G7ytptaQJSRO7du2awUeb5eRn\nm9qAayncJa0APgyMRsQ+oFznPQQcqPfnI+LGiBiJiJFFixbNpL9m+Sxs8OXRzza1AZE73CUtATYA\nl0TERKV5L7CwZtcFwJ5iumfWuvLYOOz949QNR8/xs01tYOSd5z4fuAP4XETcUrVpMzBX0hlVbWcB\n9xXXRbMWffwG2F/ny+Mz5vnZpjYwmoa7JAFfBnYC6yUNT76Ah4BNwGcknSlpFLgY+EonO21Wz+TU\nR7btqL/Do3vrt5slKM8Dsk8CLqz8/uGabW8HRoEvAhPAbmBtRHy7sB6a5XBo6mPtDJlqrrfbAGka\n7hHxINlF0um8opjumM1QvamP1ebNdb3dBooXDrM0TDfF8cRhuH6t6+02UPKUZcx63+IT6tfaTxym\ndK+XObLB45G7pWHdmqz0Us2lGBtgHrlbEkqjKylDVnvfvjMbya9b41KMDSyHuyWjNLoSHOZmgMsy\nZmZJcribmSXI4W5mliCHu/U9P3HJbCpfULW+NmXZgcknLoFnythA88jduqKw0bafuGRWl0fuNusK\nHW37iUtmdXnkbrOvyNF2o5UevQKkDTiHu82+IkfbXnbArC6Hu82+AkfbpdGVcP3abOVHqeEKkJ5R\nY4PGNXebfevWTH2wRhuj7WbLDnhGjQ0ij9ytUHlGyHlH24XxjBobQB65W2FaGSHP6iJfnlFjA8gj\ndytOr46QPaPGBpDD3YrTqyNkz6ixAeRwt+L06Ah51mv8Zj3ANXcrTsGzYIrkB3nYoMk1cpd0vKQr\nJf1a0lFV7RdIiprXls5113qZR8hmvaPpyF3Sp4D3AI8Dz67ZPAzcDbyyqu1AYb2znlIeG2/6jFKP\nkM16Q56yzF5gBTAEfK9m2zCwPSJ2FN0x6y2+EcisvzQty0TEJyLiBw02DwMO9kHQq9MczayudmfL\nDAMvlfQrSQ9J+oKkZxTRMesxjaYzbtvh9VrMelC74b4J+BHweuASsvLNZ9vtlPWg6aYzRhwu0zjg\nzXpCW+EeEVdHxCUR8b8RcRfwfuBN1TNqqklaLWlC0sSuXbva+WibbfVuBKrlMo1Zzyj6JqbNwBym\nzqoBICJujIiRiBhZtGhRwR9trWh1Cdwp0xwb6fbdqGYGtBHuko6W9DtJS6ual5BNhXyk7Z5Zxxya\n+bJtR0slldLoSkr3bqS058dZyNfj9VrMesKMwz0i/gz8ELhe0tmSXgRcDWyICM9172VFzHzxei1m\nPa3dssy7gd8C3wHuBH4KXNZup6zDCljgy3ejmvW23GvLRMT3AdW0PQq8rdguWaccusM0ov4OLZZU\nfDeqWe/ywmEDYsodprVcUjFLipf8TVDdmTD16uyTXFIxS45H7olptAZMw2CXKN27cfY6aGazwiP3\n1DSaCTPU4FR76qJZkhzuqWk04+VguenUxVZvbDKz3uVwT02jkXilrt5o6uJMb2wys97kmntCymPj\n8Md9UzdURujTTl2c7sYmX2g16zseufeZRqWTQyPv3Y8d+QeOOzbfTJgCbmwys97hkXsfme5pSA2n\nOh7z9HxTHBefkL1fvXYz6zseufeT6UonLY68a78BsOK8JNaK8UVhs4zDvU+Ur7im/sgaDj+wup46\n7XUvnn71m7Dq/L5eK8YXhc0Oc7j3uPLYOOXnvhz+7bbGOy0+obVVGht9A/j2jw4t6Vu6d2NfBTvg\n57yaVXHNvUeVx8bhqn+eeoG0VtVMmEO198mR/OQMmVqpXjxN9bjMZsAj9x5yqF78zBfBu9Y1D3Y4\nonQy+TANbvxYtm31R+rXnVso4fSVVI/LbAYc7j3iiHpxXkOlKSPzXHXnFefVLN5MX148ncIPEDE7\nxOHeA8pj4/DujzZe3KuRt712aluTunN5bDy7eFq9pLuAVef3X429hh8gYnaYotGDGzpsZGQkJiYm\nuvLZvaR8xTXTXyytR8A7LqJ07VVT32/BsvoP45Ao7flxNu2x3reD455Jaet/ttYPM5t1kjZFxEiz\n/Txy76Ly2HjrwQ4wdy68+Oz625rVnRtdXNz9mKcMmiXE4T6LymPjlE/9G8rPfFF20XT1upm90XTT\n+5rVnae7uOgpg2bJcLjPgslQnzIDpp2KWIMReNO683QXFz1l0CwZnufeYeUrroGbbmsvyOspifLY\neN2LhdOt/lgaXUn5qk/D7senbvSUQbNkeOTeQeWx8c4EO2QP35jprfXXXOkpg2aJc7h3wOTNSLxr\n3cyC/Z0XZeWUZmZ4a72nDJqlL3dZRtLxwNuBdwOnRcSBSvupwBeB84DdwHUR8akO9LUvlMfG4e8/\nAX/e3/ofHirB5z+alU5ql/dtZIZ18mkf3GFmfS9XuEv6FPAe4HHg2TWbbwV+D5wLnAXcLGlLRGws\nsqN9471XzyzY582dspTAEWvFlJSVYmq5Tm5mdeQdue8FVgBDwPcmGyU9H3ghcGpEPADcJ+kCYBUw\nMOFeHhvPQriVpQNqVUosh+K7egGwybViakfyrpObWQMt3aEqaTlZuM+JiAOSLgRuiYj5Vft8AFgV\nEUune69+v0M1W7WxwayTdhw9J7vDdP+Bw22VUT2Qb9VHM0tW3jtU250KeSxQu3Tho5X2ZM1oyYC8\n6pV0KqP60r0bXSc3s1zanS0zVKctGr2vpNWSJiRN7Nq1q82P7o4ZLxnQLt9gZGYtaDfcy3XeQ8CB\nOvsSETdGxEhEjCxatKjNj559h1ZvnImhNv9T+8KpmbWg3bLMXmBhTdsCYE+b79tTcj8VaTr1Zrrk\n5QunZtaidkfum4G5ks6oajsLuK/N9+0Zh+abtxPs7fANRmY2A22N3CPifkmbgM9Ieh9wBnAxcGER\nnesJ9R5+MRtq5r2bmbWiiOUHRskurE4A1wFrI+LbBbxv15SvuIbywmXZsrztzF3P4+g5cFxlctFk\nXd6jdTNrU0sj94j4PjVP34yI3wKvKLBPXVEeG8/uLv3jvs5+0HHHwjFP91x1M+soL/nL5CyYj8HB\ng8W84THz4A2vzJ5VWntH6TVXOszNrOMGMtwPLRewfScsnF/sXabHHUtp639ln/Pis31HqZl1xcCF\n+5TVFotePuDRvYd+65UXzaxbBm8996s+3dnZL77ZyMx6wMCEe3lsnPJzX17cSH1oCObUfPHxzUZm\n1iOSL8t0ZPXGE4cPh7hr6mbWg5IL9ykXS5/YN7OHZ9TzzosoXXvVkW0OczPrQUmFe8culgp4R51g\nNzPrUUmFe6FLBVRNaTQz6zd9f0G1PDZO+cxXF7tUgIBrrizmvczMuqCvR+5TyjBFmCzBuJZuZn2s\nL8O9fMU18KXb21sjHbKFul52Lvx2m2e8mFlS+i7c235+6Zyj4IZ1DnAzS1pf1dzbfn6pcLCb2UDo\nm3A/VF+fqXlz4caPO9jNbCD0Tbi3PM3xmHnZnaSSH35hZgOnf2ru23fm33eoBNd9yGFuZgOrf0bu\neVdbPGYefP6jDnYzG2j9M3Jft2bqnHY/RNrMrK6+CffS6ErK4FUYzcxy6JtwBz/ZyMwsr/6puZuZ\nWW4OdzOzBDnczcwS5HA3M0uQw93MLEGKiO58sLQLeLArHz47ngX8odudmAWDcJyDcIwwGMeZwjGe\nHBGLmu3UtXBPnaSJiBjpdj86bRCOcxCOEQbjOAfhGCe5LGNmliCHu5lZghzunXNjtzswSwbhOAfh\nGGEwjnMQjhFwzd3MLEkeuZuZJcjhXgBJx0u6UtKvJR1V1X6qpO9IelLSw5I+0M1+tmOaY7xAUtS8\ntnSzrzMl6WRJX5e0W9LvJF0r6WmVbSmdy+mOM4nzKWmxpNsl7ZH0gKS1klTZdo6kn0h6StJWSW/p\ndn87oa9WhexFkj4FvAd4HHh2zeZbgd8D5wJnATdL2hIRG2e3l+1pcozDwN3AK6vaDsxS1wojaQ5w\nF3AvcB7wHOCrwF7gI6RzLpsdZ9+fT0kl4A5gK7AMOBn4D2CbpFsr2+4C3gL8NXCTpJ9HxM+71OWO\ncLi3by+wAhgCvjfZKOn5wAuBUyPiAeA+SRcAq4C+CgQaHGPFMLA9InbMeq+K9RLgBcCyiNgL/FLS\neuC1km4hnXPZ8Dg5HO79fj5PB84Bzq8cx/2VUH8VsAM4HnhvRPwJ2CLpDcAbgaTC3WWZNkXEJyLi\nB3U2nQE8UQmDSfcAp81Kxwo0zTFCFgb9HASTtgKvqQTepKeA/SR0Lpn+OCGN87kFmF/zD9R+4Biy\nc/mbSrBP6tdzOS2He+ccCzxW0/ZopT0lw8BLJf1K0kOSviDpGd3uVKsiYltE3Dn5c+Wr/ZuA20jo\nXDY5TkjgfEbEwYh4YvJnSUvJvmXdRELnshmHe+cM1WkL0vtvvgn4EfB64BKy8s1nu9qjYnyQ7C/8\netI+l9XHCQmdT0kXSdpHdg3hGxFxG2mfyyO45t45Zab+DyP67OJUMxFxdfXPkt4PbJD0rojoy2OV\ntAL4MPDyiNgnKclzWXuckNz5/BawlOwC+L9KupQB+XsJCf5r1UP2Agtr2hYAe7rQl9m0GZjD1Fk1\nfUHSEmADcElETFSakzuXDY6znr49nxHxRETcHxFfA/4FuJQEz2UjDvfO2QzMlXRGVdtZwH1d6k/h\nJB1dmSe9tKp5Cdko6JEudWvGJM0nmyb3uYi4pWpTUuey0XGmcj4lLZf0i8r1hEkHyS4cbwaeJ2lB\n1ba+PZfTcbh3SETcT1a//IykMyWNAhcDX+luz4oTEX8GfghcL+lsSS8CrgY29NtX+MoNLl8GdgLr\nJQ1PvoCHSORcNjnOIdI4n/eQXRi+TtISScuBy4CvAd8n+4dqvaTTK6WaF5N9i0lLRPhVwAtYTnZh\n5qiqtr8Avgs8CTwMvK/b/ezAMS4EvkT2AIRHyGYkPLPbfZ3BsZ1cObZ6r7elci5zHGcq5/NcsiDf\nS/aP88eAoaptPyUbyW8F3tjt/nbi5YXDzMwS5LKMmVmCHO5mZglyuJuZJcjhbmaWIIe7mVmCHO5m\nZglyuJuZJcjhbmaWIIe7mVmC/h9Exvp0AUp0QgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f613658f8d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(fullmod.predy.flatten(), fullmod.model.XB.sum(axis=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7f6135ceafd0>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEACAYAAABI5zaHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAGx5JREFUeJzt3X+M3HWdx/Hne7aF1kpbCqVL0gI9\nq0EOItGVqlxOYjyyOTiQI+x5cIeioUBVckLPknq3aEkw5QSx9lCrgUsEDjZyCGpYUU4vQqJkewjy\n89Qr2Iot9fqDVlpoO+/74zuzOzs735nvd+c78/0xr0dCln5nduaz33Zf38+8Pz++5u6IiEixlNJu\ngIiIJE/hLiJSQAp3EZECUriLiBSQwl1EpIAU7iIiBaRwFxEpIIW7iEgBKdxFRApoRlpvfOyxx/pJ\nJ52U1tuLiOTSpk2b/uDuC1s9L7VwP+mkkxgbG0vr7UVEcsnMXoryPJVlREQKSOEuIlJACncRkQJS\nuIuIFJDCXUSkgBTuIpJb5ZFRyqeeR3n+8uDryGjaTcqM1KZCioi0ozwyClffCPsPBAe2bIOrb6QM\nlIYGU21bFqjnLiL5tPa2iWCv2n8gOC4KdxHJqa3b4x3vMQp3EcmnxYviHe8xCncRyafhlTB71uRj\ns2cFx0UDqiKST6WhQcoQ1Ni3bg967MMrNZhaoXAXkdwqDQ2CwrwhlWVERApI4S4iUkAKdxGRAlK4\ni4gUkMJdRKSAFO4iIgWkcBcRKSCFu4hIASncRUQKSOEuIlJACncRkQJSuIuIFFCkcDezxWZ2v5nt\nNrMXzWyNmVnlsXea2eNm9rqZbTazSzvbZBERaaVluJtZCXgAOAwsB1YA1wJ/Z2ZHVB77BfAO4Gbg\ndjN7R8daLCIiLUXZ8vftwDuBc9x9G/CCmd0L/BWwDTgG+Ad3fw143sw+DPwt8GSH2iwiIi1ECffn\ngaPcfV/NsYPAHOAU4DeVYK96Cjg5uSaKiEhcLcsy7n64NtjN7HTgYuB2YC6wp+5bdlWOi4hISiLP\nljGzC81sP/AE8F13vw/oa/BUD3tdM1thZmNmNrZjx45pNVhERFqLMxXyB8DpwEXAOWZ2FVBu8BoG\nHGr0Au6+0d0H3H1g4cKF02mviIhEEPkeqpXSzAsEA6rLgKuAO4Cj6546H9idWAtFRCS2KFMhzzKz\nX1amRFYdBl4HngXeYmbzax47DXgm2WaKiEgcUcoyTwH9wK1mtszMzgI+CXwb+AnwCrDBzN5eKdW8\nB7inM80VEZEoWpZl3H2nmQ0SLFB6gmA2zB3AF939sJmdD3yNYCHTy8BH3P25DrZZRERaiFRzd/dN\nwFlNHnt3gm0SEZE2aeMwEZECUriLiBSQwl1EpIAU7iIiBaRwFxEpIIW79JzyyCjlU8+jPH958HVk\nNO0miSQu8vYDIkVQHhmFq2+E/QeCA1u2wdU3BpskDQ2m2jaRJKnnLr1l7W0TwV61/0BwXKRAFO7S\nW7Zuj3dcJKcU7tJbFi+Kd1wkpxTu0luGV8LsWZOPzZ4VHBcpEA2oSk8pDQ1ShqDGvnV70GMfXqnB\nVCkchbv0nNLQICjMpeBUlhERKSCFu4hIASncRSQRWvmbLaq5i0jbtPI3e9RzF5H2aeVv5ijcRaR9\nWvmbOQp3EWmfVv5mjsJdRNqnlb+ZowFVEWmbVv5mj8JdRBKhlb/ZorKMiEgBKdxFRAooUrib2Ylm\n9h0z22lmvzOzW8zsyMpj55qZ1/33fGebLSIizbSsuZvZTOAh4GngTOB44G5gL3A90A88Afxlzbcd\nSrylIiISWZQB1fcCbwOWu/te4Dkz2wBcwES4b3X3bZ1rpoiIxBGlLLMZ+FAl2KteBw5W/r8fULCL\niGRIy567u28BtlT/bGYl4BLgrsqhfuBkM/sVcCRBCedad9+XfHNFRCSK6cyWuQ6YC2yo/HkT8Bjw\nN8AVwNnAVxp9o5mtMLMxMxvbsWPHNN5aRESiMHeP/mSzs4H7gfe7+1jIc/4auAd4k7uHDqwODAz4\n2FjDl5AcKo+ManWiSBeY2SZ3H2j1vMgrVM1sGUFoXxEW7BXPAjOB44CXo76+5Jf28hbJnqjz3I8C\nHgC+6u531hw/ojLv/fSapy8jmAr5SqItlezSXt4imRNlnrsB3wK2AxvMrL/m4T3Ao8B6M/sUwYDq\nF4B7mpVkpGC0l7dI5kQpy5wAnF/5//oyy2XAlcCXgEeAMvA94NNJNVByYPGioBTT6LiIpCLKVMiX\nAGvxtI8m0hrJp+GVk2vuoL28RVKmLX+lbdrLWyR7FO6SCO3lLZIt2vJXIiuPjFI+9TzK85cHX0dG\n026SiIRQz10i0Vx2kXxRz12i0Vx2kVxRuEs0mssukisKd4kmbM665rJLB8Qd39F40FQKd4lmeGUw\nd72W5rJLB4yP72zZBu4T4zshgR33+b1C4S6RlIYGYf0aWNIPZsHX9Ws0mCrJizu+k5PxoG5/utBs\nGYlMc9mlK+KO7+RgPCiN2WbquYtItsQd38nDeFAKny4U7iKSLXHHd/IwHpTCpwuFu4hkStzxnVyM\nB6Xw6SLWbfaSpNvsiUivmFJzh+DTxTQuQonfZk9ERKYnjZ1TFe4iIl3Q7dlmqrmLiBSQwl1EpIAU\n7iIiBaRwFxEpIIW7iEgBKdxFUqJtaqWTNBVSJAW6baF0mnruImnIyTa1kl8Kd5E05GCbWsm3SOFu\nZiea2XfMbKeZ/c7MbjGzIyuPLTWzR8zsgJm9bGaf6WyTRQogD9vUSq61DHczmwk8BLwBnAn8PXAx\nsKbylHuBfcC7gGuAz5vZeR1prUhR5GGbWsm1KAOq7wXeBix3973Ac2a2AbjAzO4E3g0sdfcXgWfM\n7FyC8H+wQ20Wyb00NpKS3hIl3DcDH6oEe9XrwEHgFGBfJdirniIIdxFpQrctlE5qGe7uvgXYUv2z\nmZWAS4C7gLnAnrpv2VU5LiIiKZnObJnrCMJ7A9DX4HEPe10zW2FmY2Y2tmPHjmm8tYiIRBEr3M3s\nbOCzwJC774dgzUX904BDjb7f3Te6+4C7DyxcuHA67RURkQgih7uZLQPuAa5w9+r98fYCR9c9dT6w\nO5nmiYjIdESd534U8ADwVXe/s+ahZ4FZZnZKzbHTgGeSa6KIiMTVckDVzAz4FrAd2GBm/TUP/xbY\nBHzZzD5NMHvmIuD8DrRVREQiijIV8gQmwvrluscuA4aAbwJjwE5gjbs/nFgLRUQktihTIV8iGCRt\n5gPJNEe6qTwyqkU0IgWlLX97lLacFSk27QrZqzK45axuXiGSHIV7r8rYlrPjnyS2bAP3iU8SCviW\ndFGURhTuMRXmFylrW85m8JNEHuiiKGEU7jFk/Rcp1oUna1vOZuyTRG7ooighFO5xZPgXKe6FpzQ0\nCOvXwJJ+MAu+rl/TlcHUhhehrH2SyAtdFCWEuXsqbzwwMOBjY2Otn5gh5fnLg+CsZ0Zp98+736Aa\n5VPPCwK93pJ+Sk9nZ2v9KbN0IPjEcPE5cPf3px7v0gUnr/Ly9y7JMbNN7j7Q6nnquceR5d5lXnpw\nYZ9+Hn4stU8SuZa18ppkhua5xzG8snGvMwu/SIsXNe7BZeHCU6vJRUg3r4hPd3SSMAr3GDL9i5Tl\nC0+tvFyEckQXRWlE4R5TVn+RMn3hqZWXi5BIzincCySrF55aubkIieScwl26Lg8XIZG802wZEZEC\nUriLiBSQwl1EpIAU7iIiBaRwL5DC7FgpIm3TbJmC0J2VRKSWeu5FkeEdK0Wk+xTuRZGXjcNEpCsU\n7kWR5R0rRaTrFO5Foa1fRaSGBlQLQnu2iEgthXuBFHnPlvLIqC5cIjEo3CXzNM1TJL5INXczO8bM\nVpnZr81sRs3xc83M6/57vnPNlZ6kaZ4isbUMdzO7CdgK/CPwlrqH+4EngONr/vuzhNsoOZXYillN\n8xSJLUpZZi9wNtAH/LjusX5gq7s3uG+a9LJESym6NZ9IbC177u5+g7v/NOThfkDBLlMlWUrRNE+R\n2Nqd594PvM/MfmVmvzWzr5vZm5NomEST2c3CEiyllIYGYf0aWNIPZsHX9Ws0mCrSRLuzZTYB/wd8\nHVgE3AZ8Bbis0ZPNbAWwAuCEE05o860l07NIEi6lFHmap0gntNVzd/cvuPsV7v7f7v4QcC1wSe2M\nmrrnb3T3AXcfWLhwYTtvLZDtWSQqpYikKuntB54FZgLHJfy60kiGZ5GolCKSrmmXZczsCGAzcI67\n/6JyeBlwCHglgbZJKxmfRaJSikh6pt1zd/c3gEeB9Wb2DjM7A/gCcI+7H0qqgdJEj5c+MjuYLJIB\n7Q6oXgl8CXgEKAPfAz7dbqMkml7eLCzTg8kiGWDunsobDwwM+NjYWCrvLflXPvW8xiWpJf2Unn6w\n+w0S6RIz2+TuA62ep/3cU5Z2aSHt95+O8sho42CHTAwmi2SBdoVMUdqlhdD3/9mT8PBjmSz1jLc5\nTEYGk0XSpp57mlKcp14eGYUrP9f4/W+/Lwh694nAz0qPvtE5q+qhwWSRVhTuaUppnvp47/dwufET\n6odhsrIwCpqfG82jFxmncE9TWje1btb7DZOVWnbYuVnSr2AXqaFwT1Na89SbBbWFHM9KLbvH5/aL\nRNXz4Z7mbJGkl+hH/lnCgrqvBB+7MNPhqW0NRKLp6XnuU2aLQBBkOQyLOD9Lq+fGuRm1blwt0l1R\n57n3drgXaCFM3J8liVAu0sVRJC8U7hGU5y8PpvvVM6O0++fdb1Ab0vhZinRxFMkLrVCNIq3ZKp2Q\nxs+S4S2HRXpdb4d7kWZepPGzhF043HOzlYFIUfV0uBdp5kUqP0ujC0pV1la2ivSYwtXcizR7I+xn\nydLPON6WsI28VH8XSVRPDqgWafZGeWQUVq6FgzX3PZk5Ay49H+7+fuZ+xiINTsuELHUkJNCbA6ph\nG3Gtvjl329qy+ouTgx2CP9/xH9PebCxskVMiC7mmOaDbzUVkedzeOE3jnaWsbiInTRUr3MNmaezc\nE/oPNLO/8DtfbXy8HPJJq8UMldBf1GvWBZ8Qao+vXBv/PExjQLeb4aGgmoYUdy2V9hWrLBM277qR\nJf1B8GS0jFOed0a8b2hR2w49N8bUXSABFsyltPlHsZoQ9yN8N+fJa05+fCq1ZVPPlGVqe9788TU4\nYma0b9y6Pds9kwXzoj83ypTHsJ592LU97JNDE6WhQUpPP0hp98+Dr60ukN2cJ685+fEVaR1ID8p1\nuE/5qL3z1eDrgnkT0wEXzG38zYsXZfsXft21zR/vK018rVyQmpYYpvELmWTJomH5q5vhoaCKr0jr\nQHpQrsO9Yc/74CGYM3u898i6VeH/QLvwCz/dmn5paDD8wgTBjTZmz5q44UarGnKzOelhEvoEE1bv\n5uwzuxceCqrYirQOpBflO9wj9Lyb/gNt8Qvf7mBr1EG80PdZtyp8f/Vqj71Wk5LS+HlodsGol9Qn\nmLDy18OPdS08FFTTE7vUJpmR6wHVJAbJmi4UanOwteUA75L+oPfaZN56+Zp1wT1Na/+awgZBK0p7\nHp9+m+ral8RgowbmRJLTGwOqCXzUDu2ZtBhsjdSrbxWiW7YFwd3kfUq3rA5uoFGr2fXYWtTKo/bG\njeRKFqp3i3RdrsO9k3cyCg3mrdsjlVvKI6PhJZVaYUFdG8L3x5iS6MDlw5QXvCfo9deLEqgGfOzC\n5D6Cq94t0nWRyzJmdgxwGXAlcLK7H6ocXwp8EzgT2Anc6u43tXq9TOznXluSOfoo2Lcf3jjY/JuW\n9AdfW5SDYpU/Qt5n/LXiznmv9fELg95/RXlkFD5xQ/jPWZn/n3RtVcvYRZIRtSwzI+KL3QR8CngV\nOK7u4XuB3wPvAk4D7jCz59090ytDptTUo8zrrvY2V1zf+PHa3na7g5Fnn9ne91f92/1QE+6loUHK\nAKtvDlbuQjDIum5VR8O2NDQICnORrokU7sBe4GygD/hx9aCZvRV4N7DU3V8EnjGzc4GLgUyHe8Oa\nehizoGePBcFeMjjc4BNPbclj8aL2eu4PPzbx/wvmNr74zJkFZZr/HJWpklN6zuuuVc9ZpMAi1dzd\n/QZ3/2mDh04B9lWCveop4OQE2paI0IHPqD3rJf2w8fNByWbnnqDGXp1bXqu+htxuz7u2fetWBTtC\n1po5A25dMzHmEKavlOl9VTK7t49IzrU7oDoX2FN3bFfleOqahlqUgcVqYK++uXGNumThA7m1Pe/p\nqGlfaWgQbhuePHB823Aw06cy24ePX9j4dT56QaRtFtII2SxfdETyrt1w72twzMNe18xWmNmYmY3t\n2LGjzbeOoFmoNZrBMXPG5K0LqoG9s/76VVH2SVMoxwNy3hntlWQazCRptZikdMvqIOBrtyWoDqa2\nWOyVWsh2eW8ffUqQXhK15h6mzNQgN+BQg+fi7huBjRDMlmnzvVtrEmrjA4sJzeBouOhpui4+Z0o7\nosw2Kd2yetLg6biw+n/100GzkO1kXb6Le/tM+fupXsBAYw9SSO323PcCR9cdmw/sbvN1k9Fi8Uyz\n3vCkXngYY7wXyOqbkwl2gLu/P3XOfDs961bzzNPaQK2bi5uyvAOoSAe0G+7PArPM7JSaY6cBz7T5\nusmY5uKZSWHajDMRtmGlm+nYfyBYiLT0LyZ67G0EU8vFXmmtIO3m4qYs7wAq0gFthbu7vwBsAr5s\nZqea2RBwEXBXEo1rV9wVrNXeOpcPJ9cLD7NgXusVrDv3BAuOwi4yW7YFny6uWdeylty0Zt+BkI1S\n3+7qZl7aAkF6TKyNw8zsLIJ57jNrVqj+CcEK1fcRrFD9F3f/UqvX6sYK1TirIhOtmbdS2RiMy4ej\nPb+v1Hj6ZTML5rWcyz55he5cwGHX3s6MP6R8h6sstklkOhJdoVrl7j+hrr/p7v8LfCBW67og9gDa\n6i92J9gNuPic4P+jhnZ17/Y47du5p+nPO3WF7p7gPTZ+vv2wS2uAtomkB9BFsi5XW/5G7YmXR0bh\nys81Ds4G29iWR0aj96KT0GLL3imq93tde1v8KZYh2/Z28p6i2uJXpHMKt+VvnBtfcPWN4T3imgG0\nSTX2booT7H194xex0tMPNl+N2kjcgcQkBhhV3xZJXW7CPfKMkVZ7xhx91MQUxxXD7S026oZS3ahr\n3NvlxQ3aJAJYW/yKpC4/4R61p9ms51myYI+YaqCnU5EK19fgr+PgoUkXsIYzTD5+YePb5zUL1A4G\nsG5pJ5K+3NTcW9WIx+vxSfXEZ86Aw4ehnMD56SsFr1Oy8HLRETOb7iXf7NZ5VXH3TNce6yL5E7Xm\nnp9wbzSV7YiZ8ObZ0fZij2PB3Gg37kjSnFlw4I3G4d9XorTzZ91ri4hkVuEGVKd81F8wLxhY7USw\nz3lTd4Md4I8Hwnv1cee4i0jPy024w+RVlsyZHdSjk7Zrb3pL0sNmwsSdISMiPS9X4T5JpwJ48aJ0\npuwtmKdZJiKSmPyGe5QAnjM7/usOr4w/3TAJ1a0Cmswy0X7kIhJVfsO9WQAbwY0qXv6veCWNBfPG\n7240pb5fP988aSuuD2YEQcMNvnTXIhGJI7fhPimAYWKO+JJ+2Lg2uHEFBBeBI2a2fsHZs2DdtZNe\nfzxkN/8Q5ke8c+DsWfCNtfHr5NXAXjFM+Zp1Ux/XfuQiEkNupkK2o7z0g81n1VT2bml696Mo52nB\nXFi3avyWe1Ombvb1BXPnWzGCC1TtzUO0X4uIUMCpkG3ZtTf2t0wpgzSzpB++sZbS5h+NB3LD+vnX\nrp/o1VuTMo8ztUeu/VpEJIbeCPdWAVgth8w7Y2KgstUeNTBegplyg+zqrfeYXD8HJq8IbbRlQFX9\nbCDNpBGRGHoj3KPMfql2zisDlU23MaibyVIeGQ1KP5cPTx7w/MQN4wOeDQdE9+0Pf4+6C5L2axGR\nOHqi5g7TqJ+XrPG+MnX7nbe8g9OCeZQ2/zB8b5w5s+G1/ZM3MdMdgkQkhGrudSatbo0yk6XsU2fZ\nGBP3La1OQWxVvqneODts0dVrB2DjWvXIRSRRsW6zVxjDK6PdL/XNs2HOMUGPu/buSTW37Iu8Unbx\nosY998WLgiBXmItIgnqm515ryhz5MLv2Ttz9qL5CU51j3mqwtjpoqgFREemingx3qCnT7Hk8WIHa\nSDW4m90opNlg7cwZsG7V+PtpQFREuqU3yzL11l07tUxT26tuUVIpw8SNQvpKwRa9DRZGqfwiIt2i\ncIfJAd3orkSNavQ14a/QFpGsUbhXNAvoluEvIpIxCveI1DsXkTzp2QFVEZEiU7iLiBSQwl1EpIAU\n7iIiBaRwFxEpoNR2hTSzHcBLqbx5Nh0L/CHtRvQQne/u0blO1onuvrDVk1ILd5nMzMaibOMpydD5\n7h6d63SoLCMiUkAKdxGRAlK4Z8fGtBvQY3S+u0fnOgWquYuIFJB67iIiBaRwT4GZHWNmq8zs12Y2\no+b4UjN7xMwOmNnLZvaZNNuZd2Z2opl9x8x2mtnvzOwWMzuy8pjOdcLMbLGZ3W9mu83sRTNbY2ZW\neeydZva4mb1uZpvN7NK021t02hWyy8zsJuBTwKvAcXUP3wv8HngXcBpwh5k97+4PdreV+WdmM4GH\ngKeBM4HjgbuBvcD16FwnysxKwAPAZmA5cCLw78AWM7u38thDwKXAB4HbzexJd38ypSYXnmruXWZm\n/wz8BOgDfgzMdPdDZvZW4H+Ape7+YuW5dwIz3P3DKTU3t8zsz4H/BI52972VY/8EXAB8GJ3rRJnZ\nnxJcSI93922VY7cRLGD6BkG4H+vur1UeexR41N2vS6nJhaeyTJe5+w3u/tMGD50C7KuGTcVTwMld\naVjxbAY+VA32iteBg+hcd8LzwFHVYK84CMwhON+/qQZ7hc53hyncs2MusKfu2K7KcYnJ3be4+/eq\nf66UDS4B7kPnOnHuftjd91X/bGanAxcDt6PznQqFe3b0NTjm6O8oKdcRhMkGdK47xswuNLP9wBPA\nd939PnS+U6EB1ewoM/UfuwGHUmhLoZjZ2cBngfe7+34z07nunB8ApxMMUv+rmV2F/m2nQuGeHXuB\no+uOzQd2p9CWwjCzZcA9wBXuPlY5rHPdIZXSzAvAC5VzfxVwBzrfXaePRdnxLDDLzE6pOXYa8ExK\n7ck9MzuKYJbGV939zpqHdK4TZmZnmdkvK2MbVYcJBrGfBd5iZvNrHtP57jCFe0a4+wvAJuDLZnaq\nmQ0BFwF3pduyfKosnvkWsB3YYGb91f+A36JznbSngH7gVjNbZmZnAZ8Evk0w9fcVgr+Ht1dKNe8h\n+EQlHaKyTLYMAd8ExoCdwBp3fzjdJuXWCcD5lf9/ue6xy9C5TpS77zSzQeBmgsHUXQTlmC+6+2Ez\nOx/4GvALgr+Pj7j7c6k1uAdoEZOISAGpLCMiUkAKdxGRAlK4i4gUkMJdRKSAFO4iIgWkcBcRKSCF\nu4hIASncRUQKSOEuIlJA/w88AQ35qsGZYAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f613658f940>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(Y, fullmod.predy.flatten())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7f6135ca1780>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEACAYAAABI5zaHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAG8FJREFUeJzt3X2QXNV55/Hvr4WEZBkhZGSGLWGg\nLKdsFhbKlsEJWxs2taamFgdMWMYOTmwS14qgEJINrGGVjUjELi5cNmtjBRMlAWpxWKGyCiPjQvYG\nx1Wxt2wyWgwBDBvbgCVjyePSCwJLQqif/eN2a3p6+uX29Mvte/v3qZoazbmt7tN3pKfPfc5zzlVE\nYGZmxVLKugNmZtZ7Du5mZgXk4G5mVkAO7mZmBeTgbmZWQA7uZmYF5OBuZlZADu5mZgXk4G5mVkDH\nZfXCJ598cpxxxhlZvbyZWS5t37795xGxvN3jMgvuZ5xxBpOTk1m9vJlZLkl6Kc3jnJYxMysgB3cz\nswJycDczKyAHdzOzAkoV3CWtkPSQpH2SXpS0VpIqx66TFHVf2/rbbTMza6VtcJdUAh4GjgIXAKuB\nG4DfqjxkDNgKnFrz9Zv96KyZWa3y5m2Uz76U8tILku+bPa6sSlMK+S7g3cAlEbELeF7Sg8CvA/eT\nBPeXKsfMzAaivHkbXH8bHDyUNOzYBdffRhkoTYxn2rdhkCYt8xxwQl3wPgIsrvx5DHBgN7PBWn/X\ndGCvOngoabf2wT0ijkbEq9WfJZ0HXAXcU2kaA35D0kuSfijpk5Lm96e7ZmYVO3d31j5iUlfLSLpC\n0kHgCeArEbGlcuj/AN8ALgX+C0lOfm2T51gtaVLS5NTUVHc9N7PRtuKUztpHTCelkF8DzgOuBC6R\ndC1ARFwfEZ+IiCcjYjPw34GPNXqCiNgYEasiYtXy5W23RjAza27dGli0cGbbooVJu6XfW6aSmnme\nZEJ1JXAt8IUGD30WWNGb7pmZNVaaGKcMSY595+5kxL5ujSdTK9oGd0kXAZ8Hzo2IcqX5KHBY0mnA\nduCsiPh55dhK4OU+9NXMbIbSxDg4mDeUJi3zFMmk6WclrawE++uAL0XEDuAF4G5J75T0a8DNJCWS\nZmaWkTTVMnuAceBfkUym/k/gPuDTlYf8B2Ae8J3KsU3Af+tDX83MLKVUOfeI2A5c1OTYDuDyHvbJ\nzMy65I3DzMwKyMHdzKyAHNzNzArIwd3MrIAc3M3MCsjB3cysgBzczcwKyMHdzKyAHNzNzArIwd3M\nrIAc3M3MCsjB3cysgBzczcwKyMHdzKyAHNzNzArIwd3MrIAc3M3MCsjB3cysgBzczcwKyMHdzKyA\nHNzNzArIwd3MrIAc3M3MCihVcJe0QtJDkvZJelHSWkmqHHu3pMclHZb0gqSP9rfLZmbWTtvgLqkE\nPAwcBS4AVgM3AL8laUHl2PeAc4HPAPdIOrdvPTYzs7aOS/GYdwHvBi6JiF3A85IeBH4d2AW8Bfij\niPgF8JykDwO/CTzZpz6bmVkbaYL7c8AJEfFqTdsRYDFwFvDDSmCvegp4Z++6aGZmnWqblomIo7WB\nXdJ5wFXAPcASYH/dX9lbaTczs4ykrpaRdIWkg8ATwFciYgswr8FDo9nzSlotaVLS5NTU1Jw6bGZm\n7XVSCvk14DzgSuASSdcC5QbPIeCNRk8QERsjYlVErFq+fPlc+mtmZimkybkDUEnNPE8yoboSuBa4\nFzip7qFLgX0966GZmXUsTSnkRZL+qVISWXUUOAw8C7xd0tKaY+cAz/S2m2Zm1ok0aZmngDHgs5JW\nSroIuA74EvBN4GfABknvqqRq3gds6k93zcwsjbZpmYjYI2mcZIHSEyTVMPcCn46Io5IuA+4mWcj0\nMvCxiPh+H/tsZmZtpMq5R8R24KIWx97bwz6ZmVmXvHGYmfVEefM2ymdfSnnpBcn3zduy7tJIS10t\nY2bWTHnzNrj+Njh4KGnYsQuuvy2plZ4Yz7Rvo8ojdzPr3vq7pgN71cFDSbtlwsHdzLq3c3dn7dZ3\nDu5m1r0Vp3TWbn3n4G5m3Vu3BhYtnNm2aGHSbpnwhKqZda00MU4Zkhz7zt3JiH3dGk+mZsjB3cx6\nojQxDg7mQ8NpGTOzAnJwNzMrIAd3M7MCcnA3MysgB3czswJycDczKyAHdzOzAnJwNzMrIAd3M7MC\ncnA3MysgB3frCd+Fx2y4eG8Z65rvwmM2fDxyt+75LjxmQ8fB3brnu/CYDR0Hd+ue78JjNnRSBXdJ\np0v6sqQ9kn4i6Q5Jx1eOfUBS1H09199u21DxXXjMhk7b4C5pPvAo8DpwIfDbwFXA2spDxoAngFNr\nvv51Pzprw6k0MQ53roXTxkBKvt+5dmgnU13ZY6MgTbXMLwO/BFwQEQeA70vaAFwO3EIS3HdGxK7+\nddOGXV7uwuPKHhsVadIyLwAfrAT2qsPAkcqfxwAHdssHV/bYiGgb3CNiR0Q8Uv1ZUgn4CLCl0jQG\n/Iqkf5b0Y0l/KenN/emuZakQ6QxX9tiImEu1zM3AEmBD5eftwLeBDwHXABcDn2/0FyWtljQpaXJq\namoOL21ZOZbO2LELIqbTGXkL8K7sKaRCDDx6TBGR/sHSxcBDwK9GxGSTx/wGsAl4U0S80ey5Vq1a\nFZOTDZ/ChlD57EuTgF7vtDFKT28dfIfmaFbOHZLKniGeALbWRu13Kml7RKxq97jUI3dJK0mC9jXN\nAnvFs8B84K1pn9tyoCDpjLxV9lgKnkdpKG2d+wnAw8AXIuKLNe0LKnXv59U8fCXwBvCznvbUslWg\ndEZpYpzS01sp7ftu8t2Bfeh0lGbJycBj0KmjNHXuAu4HdgMbJI1Vv4B5wLeAOyWdK+l84JPAplYp\nGcshL1SyAel4ficHA48s5qzSjNzfBlwG/FvgZeCnNV8fAn4P+BHwGPAI8I/Adf3orGXH6QwbmE7T\nLHkYeGSQOmq7iCkiXgLU5mFX96Q3NtTyslDJcq7DNEtpYpwyJIFy5+5kxL5uzXANPDJIHXk/dzMb\nLitOaVyZ1SLNMvQDjzm8p255V0gzGy55SLN0KoP35JG7mQ2VXKRZOpTFe+poEVMveRGTmVnner6I\nyczM8sPB3Swj3g/F+sk5d7MMeF956zeP3M2y4P1QrM8c3M2ykJP9UCy/HNzNspCD/VAs3xzczbJQ\nxIU6NlQ8oWqWgSIu1LHh4uBulpGh3w/Fcs1pGTOzAnJwNzMrIAd3M7MCcnA3MysgB3czswJycDcz\nKyAHdzOzAnJwNzMrIAd3M7MCcnA3MyugVMFd0umSvixpj6SfSLpD0vGVY2dKekzSIUkvS/pEf7ts\nZmbttN1bRtJ84FHgaeBC4FTgAeAAcAvwIPBT4D3AOcC9kp6LiK396rSZmbWWZuT+y8AvAR+PiO9H\nxDeADcAHJL0DeC/whxHxTERsArYAV/Wtx1ZYvqeoWe+kCe4vAB+MiAM1bYeBI8BZwKsR8WLNsaeA\nd/ashzYSjt1TdMcuiJi+p6gDvNmctA3uEbEjIh6p/iypBHyEZIS+BNhf91f2VtrN0vM9Rc16ai7V\nMjeTBO8NwLwGx6PZ80paLWlS0uTU1NQcXtoKy/cUNeupjoK7pIuBPwEmIuIgUG7wHALeaPT3I2Jj\nRKyKiFXLly+fS3+tqHxP0TnzXIU1kjq4S1oJbAKuiYjJSvMB4KS6hy4F9vWmezYyfE/ROfFchTWT\nts79BOBh4AsR8cWaQ88CCyWdVdN2DvBM77poo6A0MQ53roXTxkBKvt+51vcUbcdzFdZEmjp3AfcD\nu4ENksZqDv8Y2A58TtJ/IqmeuRK4rA99tTbKm7fl+obLvqfoHHiuwppIc4PstzEdrF+uO/Y7wATw\n18AksAdYGxFf71kPLZVjl+fVUVz18hxyFeCtQytOSX7XjdptpKUphXwpItTk676I+FFE/FpELIyI\nfxER/2MQHbc6vjwfTZ6rsCbSjNwtD3x5PpJKE+OUIdfpOOsPB/ei8OX5yPJchTXiLX+LwpfnZlbD\nI/eC8OW5mdVycC8QX56bWZXTMmZmBeTgbmZWQA7uZmYF5OBuA+ddDM36zxOqNlDeJsFsMDxyL5Bc\njIi9TYLZQHjkXhC5GRF7mwSzgfDIvSjyMiL2HZfMBsLBvSjyMiL2NglmA+HgXhRzGBFnkaP3HZfM\nBsM596JYt2Zmzh1ajoizzNF7mwSz/vPIvSA6HhHnJUdfkYtKILMh4pF7gXQ0Is5Ljp4cVQKZDRGP\n3EdVnqpWcnaVYTYMHNxHVZ6qVnJ0lWE2LBzcR1SuqlbydJVhNiSccx9huala6bASyMxSjtwlvUXS\njZJ+IOm4mvYPSIq6r+f6110bRbm6yjAbEm1H7pI+BfwB8Arw1rrDY8ATwL+vaXujZ72ztsqbt43E\nfVNzc5VhNiTSpGUOABcD84C/rzs2BuyMiF297pi15xJBM2umbVomIm6NiH9ocngMcGDPiksEzayJ\nbqtlxoBfkfTPkn4s6S8lvbkXHbMUhrxE0KtKzbLTbXDfDnwb+BBwDUn65vPddspSGuISwWMpox27\nIGI6ZeQAbzYQXQX3iPhkRFwTEf83Ih4FbgA+UltRU0vSakmTkianpqa6eWmD4V6I5JSRWaZ6vYjp\nWWA+s6tqAIiIjRGxKiJWLV++vMcvPXqGukSwjykjp3vM2pvzIiZJC4AXgEsi4nuV5pUkpZA/60Hf\nLIWhLRFccUqSimnU3gVXCJmlM+eRe0S8DnwLuFPSuZLOBz4JbIoI17qPun6ljJzuMUul27TM7wE/\nAh4DHgH+Ebiu205Z/vUtZTTkFUJmwyJ1WiYivgmorm0vcHVvu2SDMIiVrX1JGfUp3WNWNN4VcgTl\nukxxmCuEzIaIg3uBpK4iyXHeeqgrhMyGiLf8LYiOqkhynrce2gohsyHikXtRdDIaH+KVrWbWGw7u\nRdHJaLwgeWsvZjJrzsG9KDoYjRchb53rSWGzAXBwL4oOR+OliXFKT2+ltO+7yfc5BvbMRs85nhQ2\nGwQH94LIYjTecPS8eh3lE8/vf6DP+aSwWb+5WqZABl5F0mj0HJXv/d7zxYuZzFryyL1DRZvE6+r9\ntBsl9zNNUpBJYbN+cXDvwKAn8ZoF3l59wHT9ftKMkvuUJinCpLBZPyki2j+qD1atWhWTk5OZvPZc\nlc++tHEq4LQxSk9v7e1r1S9KgmRketUl8MBXZ7fPIbB1+34a9nGOz2XDaRB7EFlnJG2PiFXtHueR\neycGOYnXrBrkvod6VyXSrN+NAn4DM0bPULetHE6T5JzLTfNtJIJ7qzRGRymOQa7sbBZ4j5Y7e3yN\n+vfKSSc0f+wf356ml9Mllfsfh43rO06TFG0Oo1BcbpprhU/LNE1v3Lk2+XOTY42CUqvn6vWlatOU\nSTNt0h8N+75gPrx+pO3z9utSfJDn0zpXXnpBMmKvJ1Ha993Bd8gAp2WmtRp9dDgyGegk3ro1s9Mc\nrbz2i9aj3kbvtV1gh/5eintkONy8B1GuFT+4t8qTzyGH3quVnVXN0hKlifHpmvFGFi+a+fOeV1oH\n4W7mBfoVcL0Qabi53DTXir+Iqd1ilwwXwrTaphdIRu7NAvyhw7PbqkG40QdOs/OQVj8CrhciDbXS\nxHjyb9HVMrlU/JF7q9FHn0cmx0blJ55Pedn7Zi/Lb5cyajVy73RitdF77UQ/Au6AR4aevO1cr69U\nbXAKP6EKrWt1Zxw7aQkQsPdA8riLL4Svf3tOo5ZUNeDNqJJsb/W7aTaqbzGxWt68Df7jus7708dJ\nzkHVUXvy1ooi7YRq4YL7XINFqmDcQTDouNqlVrVuvNXfnzcPSoIjb0y3LZgPb140/eHU4L2n7te8\nEpSjMJfig1yAZtZPI1kt09Wii0Ypkno1E4ttL/HnmqNulTKqdfQonLB4unJn2YnJe97zSuv3nqYK\nZ9FCuPvPinUp7slbGzGFCu5dldal/U++YxflM98Pa9a3/hDpNEddV1o5a/VnI3tfOZYPZfGimaN4\naPjeSxPj8LtXzA7w1Z+LukeLy/psxKQO7pLeIulGST+QdFxN+5mSHpN0SNLLkj7Rn66m0M3orJP/\n5Hv2tw+knUxgLl6UvP7O3bD+rhnlkKWntzYP8LV9bpZqadBeuuOm2atJN66ntP/x4ozU67msz0ZM\nquAu6VPATuA/A2+vO/wg8CrwHuCPgT+XdGkvO5laN6OzbqtJYMaHSKqRd9VrB2deBaxZP/MqIE1g\nmtfkV1lpn7X1AIxUFYR3kbRRk3bkfgC4GPhQbaOkdwDvBf4wIp6JiE3AFuCqnvYyrUZBcP5x8NrB\nprnxatBj9S2waEGSu67+5//4FemCc1WvLvGPvAE3ffrYj6kCU7PSyKPlodgAahjKEF3WZ6Mk1SKm\niLgVQNJFdYfOAl6NiBdr2p4io+A+a9HFSSfAqweTNArMujvQrAqZPa8kHw4b/3zGf/zyme+ffo5m\n6kbS5c3b4PdvTbfEv5E9r3T2+NPGmlaDtJyLGECAa7VYywHWrD+6nVBdAtRHvb2V9oFolW5g8Ztm\nB9fa3HiKCdjy5m1w4LXZL1wqTU9CzivBVZfMrJ2/5pa5B/Y6xz4oakfev39r+tRN1pUi3kPGbOC6\nDe7zGrRFs+eVtFrSpKTJqampLl86Relju6CWJuitv2v25ClAuTy9iOhoGR74avJBU+1Tucv1A7V7\nx9z0mdkfFK8fgZs+0zqtVE3dZF0p0uI8D0O6xqyIug3u5QbPIaBBNISI2BgRqyJi1fLly7t8adqP\nCNsFtTRBL+3o9uAh+KPbkhWgaValNpsArTp+wfSfm6WE9uyf+eG25xU4eDhJK9XmlFNMyPY1yDY7\nzyctyXwuwKyoug3uB4CT6tqWAvu6fN502o28L76w9d2BWhw/NiLuZAXvax1sNXD15a2rc/bsp3zm\n+9sHuhTpjnYTsn2fcG324UIMNF3jqwQbJd0G92eBhZLOqmk7B3imy+dNp8XIu7x5W3Kv0drYLI7l\nxlsdB6aDXT8sW5LsWdNuhL9nf5JrX9xhiWaDD72WlSJ9zok3+3Bh74HU/e/WMFQMmQ1SV8E9Ip4H\ntgOfk3S2pAngSuBve9G5tlqlGxoFrCAJqtD8+H0PpU+tzMWihXD7jekD2OtH4Pjjk5LOWvOPS/Lr\njUR0NjLtw4Rrqrr6Qc4FeFLXRkwvth+YIJlYnQQ+C6yNiK/34HnbajoihOaj7naTqc3qxestmJ+M\nwKF9/ryqtqqmxf1LZ9n7Cty1bub7vGsd3H5D89ROJyPTHgfZ1KPkQa4azbpiyGzAcrUrZJodH9vu\n7ljZBbCrXRtLSqphFi9KVpd2YsF8mD+vs/x83c6FM87Dmxa27kO7LYDX35Wch/othLvYDreTHRgH\ntuWvd4W0gijcrpCpR4OtdnesHRWuWzM71ZG6M5Uo2GlghyTN0klgXzB/9uKo2vPQrg9NRqYzngeS\nwN6rzcM6GCUPbNWo95axEZOb4J46Z9rqMrtmoRHfebJx/XrWFtR84JQEv31p+8nPVpqlVprNOVRG\nsl0F2azr6hvw3jI2avJzD9U2o8Fjl/et0kwPfDXZnuChv2u/nUAWlp0Ir/5i+udywP1bKb/v3Okg\n1EmOuNXItJ856HVrGt/1KONRcmlifCDbLZgNg/yM3JuN+kqifOL5SYVLuxz6wUPwN1uGM7ALOPx6\n05Wox6Qd/S47sfXItI+ja4+SzbKXn+DebEvetNUtnUhb/dJLQfP8ee2HUaPzUK3cqQbSv1pP6YX/\n3TqY9jkH7R0YzbKVm7TMrB0fS+pPYIfu94WZi2VL2u4EeSz1dPBQ8gF0tJwE8zlUmMw6nwW5V6qZ\nJXJVClmrvPSCzrYGSCvNzan7oVpe2ciyJcnCp0Z5bKc7zEZK4UohZ+lX5UWam1P3Q7PAPv+4JLB7\nhaWZdSC/wb1PAXjWzamlZHKyVL/D2ABUVqKWJsa9wtLMOpLb4D7rHqXVSdDq7fHmEvhrJlJLE+PJ\nB8iKU5Ll/51atgTmNdruPiVp5kTkENaOm9nwym1wh5qKjP2PU9rzneT701sp3XHT7JF3GldffuyP\ns1aCpp1kXbSwUq3yd3D3Lelfu1590PYKSzPrQG4nVDuRah+ZeYKjlXNRDchp6uGXLQE0+7HzSnD1\n5ckHTdo+VAnYuL7xvjmubjEbaWknVHNTCtmVNHnpozUfcmkXOS1aCJe/P9kXftbzleFvtiS3qrrj\npvS5cQG/e0XDoO0VlmaWVq7TMqn1Iy+9bEmS+ml30437Hmrdh2UnzlzJuXH9sdG+mdlcjUZw70dl\nzcHXk+/tRuTVhVbNcua33+CVnGbWcyMR3GeVNqbdXmDZkulqnHrVGvN2VwWV1/J+K2Y2SCMR3GHm\nXifc/WftR/IL5sPtNyY3clCTGvedu9tfFdRU4Hi/FTMblJEJ7rUaLlKqvQn1shPhL/40VY35rHr7\nqnkl+PgVzp+bWSZGohSyWw1v3ed9XcwsAy6F7CHvoGhmeePgnpJrzM0sT0Yy525mVnQO7mZmBeTg\nbmZWQA7uZmYF5OBuZlZAmdW5S5oCXsrkxYfTycDPs+7ECPH5Hhyf6946PSKWt3tQZsHdZpI0mWZh\ngvWGz/fg+Fxnw2kZM7MCcnA3MysgB/fhsTHrDowYn+/B8bnOgHPuZmYF5JG7mVkBObhnQNJbJN0o\n6QeSjqtpP1PSY5IOSXpZ0iey7GfeSTpd0pcl7ZH0E0l3SDq+csznusckrZD0kKR9kl6UtFZK7nQj\n6d2SHpd0WNILkj6adX+LzrtCDpikTwF/ALwCvLXu8IPAT4H3AOcA90p6LiK2DraX+SdpPvAo8DRw\nIXAq8ABwALgFn+ueklQCHgZeAC4ATgf+F7BD0oOVY48CHwX+HXCPpCcj4smMulx4zrkPmKQ/Bb4J\nzAP+HpgfEW9Iegfw/4AzI+LFymO/CBwXER/OqLu5JenfAN8AToqIA5W2/wpcDnwYn+uekvQvST5I\nT42IXZW2u0gWMP0VSXA/OSJ+UTn2LeBbEXFzRl0uPKdlBiwibo2If2hw6Czg1WqwqXgKeOdAOlY8\nLwAfrAb2isPAEXyu++E54IRqYK84AiwmOd8/rAb2Cp/vPnNwHx5LgP11bXsr7dahiNgREY9Uf66k\nDT4CbMHnuuci4mhEvFr9WdJ5wFXAPfh8Z8LBfXjMa9AW+HfUKzeTBJMN+Fz3jaQrJB0EngC+EhFb\n8PnOhCdUh0eZ2f/YBbyRQV8KRdLFwJ8AvxoRByX5XPfP14DzSCap/0LStfjfdiYc3IfHAeCkural\nwL4M+lIYklYCm4BrImKy0uxz3SeV1MzzwPOVc38tcC8+3wPny6Lh8SywUNJZNW3nAM9k1J/ck3QC\nSZXGFyLiizWHfK57TNJFkv6pMrdRdZRkEvtZ4O2SltYc8/nuMwf3IRERzwPbgc9JOlvSBHAl8LfZ\n9iyfKotn7gd2AxskjVW/gB/jc91rTwFjwGclrZR0EXAd8CWS0t+fkfwe3lVJ1byP5IrK+sRpmeEy\nAfw1MAnsAdZGxNez7VJuvQ24rPLnl+uO/Q4+1z0VEXskjQOfIZlM3UuSjvl0RByVdBlwN/A9kt/H\nxyLi+5l1eAR4EZOZWQE5LWNmVkAO7mZmBeTgbmZWQA7uZmYF5OBuZlZADu5mZgXk4G5mVkAO7mZm\nBeTgbmZWQP8fNWC4YM60kdIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f6135ce2160>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(Y, fullmod.model.XB.sum(axis=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([  1.,   0.,   0.,   1.,   3.,   8.,  22., 111.,   8.,   5.]),\n",
+       " array([-5.91453093, -5.09364162, -4.27275231, -3.451863  , -2.63097369,\n",
+       "        -1.81008438, -0.98919507, -0.16830576,  0.65258355,  1.47347286,\n",
+       "         2.29436217]),\n",
+       " <a list of 10 Patch objects>)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX8AAAEACAYAAABbMHZzAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAD7BJREFUeJzt3X+s3XV9x/HnC4rgmKUV7oIxQhk/\n7Bq66CjOzWRbiGOLvyhb6CZGJ0tWs8yhGCUOtxDc0GmcWmXBVNEZfwyW1QHZgmuGkizZH3pLRrUC\nDgWq1kGxpWnFVmvf++OcO46X0/b2nm/vOe3n+Uhuzj2f7/d835/7zbev8z2f7/d8mqpCktSWE8bd\nAUnSwjP8JalBhr8kNcjwl6QGGf6S1CDDX5IaZPhLUoMMf0lqkOEvSQ1aNO4OHMwZZ5xRy5YtG3c3\nJOmYsWnTpieqamou605s+C9btozp6elxd0OSjhlJHp3rug77SFKDDH9JapDhL0kNMvwlqUGGvyQ1\nyPCXpAYZ/pLUIMNfkhpk+EtSgyb2G76SJseB014ylron7PrKWOq2wDN/SWqQ4S9JDTL8JalBhr8k\nNcjwl6QGGf6S1CDDX5IaZPhLUoMMf0lqkOEvSQ0y/CWpQYa/JDXI8JekBhn+ktSgOYV/ktOTvD3J\nQ0kWDbSfk+TuJHuTbEty7azX/XaSLUn2Jbk/ye92/QdIko7cYcM/yfuB7wLvAM6dtfg2YA9wEfA2\n4IYkr+m/bgr4F+CfgV8GNgAbkpzZWe8lSfMylzP/3cClwB8MNiY5H7gYeEtVbamqW+kF/JX9VVYD\nT1TV9VX1IPBXwI5+uyRpjA4b/lX111X1n0MWrQD2VNUjA22bgeUDy782sJ3qP1+OJGmsRrnguxjY\nNattZ799LsslSWMySvifOKStBrZ5uOXPkGRtkukk09u3bx+ha5KkQxkl/A8MeX2A/XNc/gxVtb6q\nVlXVqqmpqRG6Jkk6lFHCfzewdFbbEuDJOS6XJI3JKOH/DeCUJCsG2lYCWwaWvzjJCQBJAlw4sFyS\nNCbzDv/+7ZubgHVJLkyyBrgC+Fx/lduBnwfel+SFwA30PgncOVqXJUmjGnV6hzX0LuxOAx8Grquq\njQBV9Rjwe8Ar6d3i+fvA5VX1gxFrSpJGtOjwq/RU1T30LtgOtn0buOQQr9lI735/SdIEcWI3SWqQ\n4S9JDTL8JalBhr8kNcjwl6QGGf6S1CDDX5IaZPhLUoMMf0lqkOEvSQ0y/CWpQYa/JDXI8JekBhn+\nktQgw1+SGmT4S1KDDH9JapDhL0kNMvwlqUGGvyQ1yPCXpAYZ/pLUIMNfkhpk+EtSgwx/SWpQJ+Gf\nZHGSTyZ5Ism2JO9PclJ/2TlJ7k6yt7/s2i5qSpLmb1FH2/kQcBFwKbAU+EdgB/C3wG3A9/vLVwKf\nSvJAVd3ZUW1J0hHqKvwvA/6squ4FSPL3wGVJNgAXA+dU1SPAliSvAq4EDH9JGpOuxvx/Dtg38Pyp\nftsKYE8/+GdsBpZ3VFeSNA9dhf8G4C1JliR5AfAnwD8Bi4Fds9bd2W+XJI1JV+F/NfCLwA+Arf3H\n9wEnDlm3OqwrSZqHrkL4FuAh4GXAy4HTgHcDB4bUCLB/2EaSrE0ynWR6+/btHXVNkjTbyBd8k1wA\nXM7TF3VJ8ufAXcBV9O7+GbQEeHLYtqpqPbAeYNWqVTVq3yRJw3Vx5v+s/uPegban6L2xfB04JcmK\ngWUrgS0d1JUkzVMX4f8A8CDw0SS/lOTF9Mb7v1RV9wGbgHVJLkyyBrgC+FwHdSVJ8zRy+FfVfuCV\nwMnAfwEbgUfp3csPsIbehd9p4MPAdVW1cdS6kqT56+RLXlX1LeA1B1n2beCSLupIkrrhLZeS1CDD\nX5IaZPhLUoMMf0lqkOEvSQ0y/CWpQYa/JDXI8JekBhn+ktQgw1+SGmT4S1KDDH9JapDhL0kNMvwl\nqUGGvyQ1yPCXpAYZ/pLUIMNfkhpk+EtSgwx/SWqQ4S9JDTL8JalBhr8kNcjwl6QGGf6S1CDDX5Ia\n1Fn4J1maZF2SrUm+OND+K0m+kmRfkoeTvKGrmpKk+VnUxUaSPBv4MvAU8EZgc7/9WcAdwF3AG4CX\nA59Mcl9V3ddFbUnSkesk/IE3A1PABVX1w4H23wROB95aVU8BDyT5Q+C1gOEvSWPS1bDPa4F1s4If\nYAXwrX7wz9gMLO+oriRpHkYO/yQnASuB5yb5apLvJrklyanAYmDXrJfs7LdLksaki2Gf5/a3sxq4\nGvgx8HHgo8DWIesXB3nTSbIWWAtw1llnddA1SdIwXQz7nNx/vKqqNlbVPcC1wOuBA0NqBNg/bENV\ntb6qVlXVqqmpqQ66Jkkapovwf5ze2fzegbb76X0a+CmwdNb6S4AnO6grSZqnkcO/qvYC3wReOtB8\nLr3hn2ng3CRLBpatBLaMWleSNH9d3er5AeDGJA8BO4D3Ap8G7qH3yeCmJDcCv0XvTeJNHdWVJM1D\nJ+FfVZ9I8nzg8/2m24G3VdW+JJcBHwP+G9gG/FFV3d9FXUnS/HR15k9V3QDcMKR9E3BxV3UkSaNz\nYjdJapDhL0kNMvwlqUGGvyQ1yPCXpAYZ/pLUIMNfkhpk+EtSgwx/SWqQ4S9JDTL8JalBhr8kNcjw\nl6QGGf6S1CDDX5IaZPhLUoMMf0lqkOEvSQ0y/CWpQYa/JDXI8JekBhn+ktQgw1+SGmT4S1KDDH9J\nalCn4Z/k3UkqyXn95+ckuTvJ3iTbklzbZT1J0vws6mpDSc4F3j6r+Tbg+8BFwErgU0keqKo7u6or\nSTpyXZ75fwT4wsyTJOcDFwNvqaotVXUrsAG4ssOakqR56CT8k6wGLgTeM9C8AthTVY8MtG0GlndR\nU5I0fyOHf5JnAx8CrgGeGli0GNg1a/Wd/XZJ0hh1ceb/LuDBqvrCrPYTh6xbh6qZZG2S6STT27dv\n76BrkqRhRgr//rj+1f2f2Q4M2X6A/QfbXlWtr6pVVbVqampqlK5Jkg5h1DP/twGnAvcm2QNs6bff\nB7wAWDpr/SXAkyPWlCSNaNTwvx54IfCi/s8r+u2vBv4DOCXJioH1V/L0G4QkaUxGus+/qh4HHp95\nnmRmSGdrVT2UZBOwLsk19O7+uQK4bJSakqTRHe3pHdbQu/A7DXwYuK6qNh7lmpKkw+jsG74A/Xv6\nM/D828AlXdaQJI3Oid0kqUGGvyQ1yPCXpAYZ/pLUIMNfkhpk+EtSgwx/SWqQ4S9JDTL8JalBhr8k\nNcjwl6QGGf6S1CDDX5IaZPhLUoMMf0lqkOEvSQ0y/CWpQYa/JDXI8JekBhn+ktQgw1+SGmT4S1KD\nDH9JapDhL0kNMvwlqUGdhH+Ss5PcnmRHku8l+WCSk/vLzklyd5K9SbYlubaLmpKk+Vs06gaSnATc\nBXwdeBnwPODzwG7geuA24PvARcBK4FNJHqiqO0etLUman5HDH/g14ALgV6tqN3B/kpuAy5N8FrgY\nOKeqHgG2JHkVcCVg+EtH4MBpLxl3F3Qc6WLY52FgdT/4Z+wDfgKsAPb0g3/GZmB5B3UlSfM08pl/\nVX0H+M7M8yQnAK8DPgcsBnbNesnOfrskaUyOxt0+76QX7jcBJw5ZXgerm2Rtkukk09u3bz8KXZMk\nQcfhn+RS4F3Amqr6EXBgSI0A+4e9vqrWV9Wqqlo1NTXVZdckSQM6C/8k5wG3Am+qqul+825g6axV\nlwBPdlVXknTkurrP/znAHcDNVfXZgUXfAE5JsmKgbSWwpYu6kqT56eI+/wCfAR4Dbkpy5sDircAm\nYF2Sa+jd/XMFcNmodSVJ89fFff5n8XSYb5u17CpgDfAJYBrYAVxXVRs7qCtJmqcubvV8lN5F3EO5\nZNQ6kqTuOLGbJDXI8JekBhn+ktQgw1+SGmT4S1KDDH9JapDhL0kNMvwlqUGGvyQ1yPCXpAYZ/pLU\nIMNfkhpk+EtSgwx/SWqQ4S9JDTL8JalBXfxPXlJTDpz2knF3oRnj3Ncn7PrK2GovBM/8JalBhr8k\nNcjwl6QGGf6S1CAv+ErSEOO62LxQF5o985ekBhn+ktQgw1+SGuSYv45ZftlKmr8FOfNPcnqSDUl+\nmOSJJH+XxE8dkjQmC3XmfzPwfODXgTOBzwOPAh9ZoPqSpAFH/ew7yanAauCdVXVfVf07vTeDK492\nbUnScAtx5n8ecBLwtYG2zcCbj1bB4/3+3EniuLt0bFqIcffF/cddA207B9olSQtsIc78TxzSVkBm\nNyZZC6ztP92T5MEjqHMG8MSRd69DecafNInGv5+ODe6nuXE/zc3c99NoOXL2XFdciPA/0H8c/JQR\n4KezV6yq9cD6+RRJMl1Vq+bz2pa4n+bG/TQ37qe5mcT9tBDDPrv7j0sH2pYATy5AbUnSEAsR/v8D\n7AcuGmhbCWxZgNqSpCGO+rBPVe1Jcgfw3iT/C5wO/Cnwro5LzWu4qEHup7lxP82N+2luJm4/paqO\nfpHkDODjwO8AP+r//he1EMUlSc+wIOEvSZosx9X8OkmWJlmXZGuSL467P5MuybuTVJLzxt2XSZPk\n7CS3J9mR5HtJPpjk5HH3a1I4X9fcTPJxdNzM6pnk2cCXgaeAN9L7FrEOIsm5wNvH3Y9JlOQk4C7g\n68DLgOfRm49qN3D9GLs2SZyv6zAm/Tg6boZ9krwDeCtwQVX9cNz9mXRJ/o3eN61fB5xfVQ+NuUsT\nI8lvAF8CllbV7n7bXwKXV9VFh3xxA/rzde0ELq2qe/ptfwO8vKpeOs6+TZJJP46Op49prwXWGfyH\nl2Q1cCHwnnH3ZUI9DKye+Qfbtw/4yZj6M2kONl/X8vF0Z2JN9HF0XIR//+PVSuC5Sb6a5LtJbumf\noWhAf3jsQ8A19IbINEtVfaeq/nXmeX8s+3XAhvH1aqI4X9ccTPpxdEyN+Sd5Fs98wyp63xheRG/q\n6KuBH9O7nfSjwB8vZB8nwcH2U1Xto/f9iger6gtJli103ybJYfbToHfSC7abFqRjk2/O83XpZ0zU\ncXSsnfnfS+97AoM/DwIzV8+vqqqN/XHIa4HXJzmm3uA6MnQ/JTmf3pvj1WPs2yQ52PH0/5JcSu8N\nc01V/WjBeziZ5jxfl3om8Tg6poKxqi4c1p7kFHpnHnsHmu+n9/f9ArDt6PduchxiP90MnArcm97M\ngTNnavclubGqmroGcLD9NKN/C+ytwJuqanphenVMGJyv67H+787XdRCTehwda2f+Q1XVXuCbwOCd\nBufSG/55bOiL2nQ98ELgRf2fV/TbXw18bFydmkRJngPcAdxcVZ8dd38mjPN1zdEkH0fH1Jn/YXwA\nuDHJQ8AO4L3Ap6vKj6J9VfU48PjM8yT7+79uraod4+nV5EnvY9Fn6J043JTkzIHFuyblY/u4LOB8\nXce0ST+Ojpv7/AGSXM/T/z3k7cA1VbVnjF2aaP0Lvg/jff4/I8nZwCMHWXxVVf3DwvVmMjlf1+FN\n+nF0XIW/JGlujosxf0nSkTH8JalBhr8kNcjwl6QGGf6S1CDDX5IaZPhLUoMMf0lqkOEvSQ36Pzsh\nywrKOlo3AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f6135c8b1d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(fullmod.model.XB.sum(axis=1) - fullmod.predy.flatten())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import scipy.linalg as scla"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "hats = [m.S for m in fullmod.model.models]\n",
+    "resids = np.vstack([m.resid_response for m in fullmod.model.models]).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "partial_sums = np.vstack([np.delete(resids, i, axis=1).sum(axis=1) for i in range(resids.shape[1])]).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "test = fullmod.model.models[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "full_S = np.zeros((N,N))\n",
+    "In = np.eye(N)\n",
+    "Xc = np.hstack((np.ones_like(Y), X))\n",
+    "XBfinal = Xc * fullmod.params\n",
+    "outs = []\n",
+    "for i,S in enumerate(hats):\n",
+    "    outs.append(S.dot(Y - partial_sums[:,i].reshape(-1,1)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "full_S = np.zeros((N,N))\n",
+    "Yi = Y/scla.norm(Y)\n",
+    "In = np.eye(N)\n",
+    "Xc = np.hstack((np.ones_like(Y), X))\n",
+    "XBfinal = Xc * fullmod.params\n",
+    "for i,S in enumerate(hats):\n",
+    "    partial_prediction = XBfinal[:,i]\n",
+    "    other_partial_predictions = np.delete(XBfinal.copy(), i, axis=1)\n",
+    "    sum_smooths_notj = other_partial_predictions.sum(axis=1).reshape(-1,1)\n",
+    "    contribution = S - S.dot(sum_smooths_notj*Yi)\n",
+    "    full_S += contribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[-0.23547867, -0.18206638, -0.18977909, ..., -0.29895659,\n",
+       "        -0.25056738, -0.17931646],\n",
+       "       [-0.29946308, -0.23108195, -0.24124034, ..., -0.38131366,\n",
+       "        -0.31902609, -0.227077  ],\n",
+       "       [-0.17403517, -0.13446435, -0.14024052, ..., -0.22119849,\n",
+       "        -0.18529201, -0.13235877],\n",
+       "       ...,\n",
+       "       [-0.57419052, -0.44844146, -0.46296288, ..., -0.70912319,\n",
+       "        -0.60242697, -0.44093733],\n",
+       "       [-0.48304757, -0.37579771, -0.38941698, ..., -0.60575178,\n",
+       "        -0.50733731, -0.36858272],\n",
+       "       [-0.33244098, -0.2563666 , -0.26766657, ..., -0.42358667,\n",
+       "        -0.35337764, -0.25044472]])"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "S - S.dot(sum_smooths_notj * Yi.T)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([8.0000e+00, 2.2000e+01, 1.8500e+02, 3.3310e+03, 2.0379e+04,\n",
+       "        1.2390e+03, 1.0000e+02, 1.5000e+01, 1.0000e+00, 1.0000e+00]),\n",
+       " array([-2.65253985e+15, -2.04252447e+15, -1.43250908e+15, -8.22493702e+14,\n",
+       "        -2.12478320e+14,  3.97537062e+14,  1.00755244e+15,  1.61756783e+15,\n",
+       "         2.22758321e+15,  2.83759859e+15,  3.44761397e+15]),\n",
+       " <a list of 10 Patch objects>)"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAERCAYAAABsNEDqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAE+lJREFUeJzt3X2wXXV97/H3JwSKiiQphB76wIPQ\nS0pBsTmljG3VTq/oqNVgR6Qw1tvbijLTVqWW0VjqULEMTnXUUh+wrdxqboFKAQdrS0exFS536Ilt\noQlYUPABCg0SYqIhEvPtH3udut05yTm/c06y9zl5v2bO7L1/37XW/q5J9vmctddev52qQpKkmVoy\n7AYkSQuLwSFJamJwSJKaGBySpCYGhySpicEhSWpicEiSmhgckqQmBockqcnSYTewLxx55JF13HHH\nDbsNSVpQ1q9f/2hVrZxuuUUZHMcddxwTExPDbkOSFpQkX5nJcr5VJUlqYnBIkpoYHJKkJgaHJKmJ\nwSFJamJwSJKaGBySpCYzCo4kxya5IcljSR5M8p4kP9DVjk/ymSRPJHkoyUUD674gyYYkO5LcneRF\nA/ULu21uT3JLkhP6aocm+bMkW5J8M8lVSZ4yHzsuSZqdaYMjycHAp4HvAD8LvBo4F1jbLXINsA1Y\nDVwIXJLkZd26K4HrgU8AzwSuA65LMtbVXwxcCrwJGAe+BVzb9/R/ADwPeGH381zgnbPeW0nSnKWq\n9r5A8lzgs8CKqtrajf0ecBZwDvDvwPFV9UBX+ziwtKrOSfJa4G1VdVxXC/BV4J1V9aEk64Anq+p/\ndfUTgXuBn6iqe5I82K1/VVf/DeDSqhrbW8/j4+PllePam13LTh/acy/ZcsfQnlvamyTrq2p8uuVm\n8lbV/cCaydDo7ACeBE4Gtk2GRudOYFV3/2TgrslC9VLqrr3U7wO2A6uSLAN+uL/ebfuHkiyfQd+S\npH1g2rmqquprwNcmHydZApwHrAMOB7YMrLK5G2eO9clltgzUJtd7fLreJUnzbzafqnoLvV/cVwAH\nTVGvvu3Opb6nGvhpMEkamqbZcZOcCbwNeF5VbU+yi91/iQfY2d2fS31X93jJQI2+9ft7Ox84H+CY\nY46Zye5IkmZhxn+5dyeurwZeV1WTZ563AisGFl3O995Gmkt98pzKioEa7P72FlV1ZVWNV9X4ypXT\nTicvSZqlmV7H8XTgRuCDVfXxvtJG4NAkJ/eNnQps6Ks/uzsvMvmpqlMG6qv7nucZwFOBjVW1GXi4\nv95t+6sDJ+olSfvRTK7jCPAx4BHgiiRjkz/0Plq7HnhfklOSnA28kt6Jc4AbgMOAy5OcBFxC7wji\nk119HbAmyau78HkvcHtVfbmv/tYkP5/kDHrXjkxuW5I0BDM5x3EM8PLu/kMDtV8Dzgb+FJgAHgPW\nVtXNAFX1SJJX0AuEN9C7RuOsqvpGV78pyVrgcuAHgdvoXVw46eJu/FPd47+iFz6SpCGZ9gLAhcgL\nADUdLwCUdjefFwBKkvTfDA5JUhODQ5LUxOCQJDUxOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklS\nE4NDktTE4JAkNTE4JElNDA5JUhODQ5LUxOCQJDUxOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklS\nE4NDktTE4JAkNTE4JElNDA5JUhODQ5LUxOCQJDUxOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklS\nE4NDktTE4JAkNTE4JElNDA5JUhODQ5LUZEbBkeSIJG9Ocl+SpX3jL01SAz/39NV/KskdSXYkuT/J\nrw5s97wkX+rqE0nG+2pJcnmSTUm+neSGJCvnY6clSbM3bXAkeRfwdeB3gRMGymPAPwNH9/38XLfe\nIcCNwL8AzwLeDfx5kmd19VOAq4A/6ur/AtyY5NBu2xcA/xs4F3gO8CPAh2e3m5Kk+bJ0+kXYCpwJ\nHATcMlAbA75eVQ9Psd7zgCOAN1bVt4F7kpwD/Arwr93tbVX1QYAkbwLOA54P/G13/0+q6u+7+luB\nTyc5rKq2Ne2lJGneTHvEUVXvqKrP76E8BkwVGgAnA1/qQmPSncCqvvpdfc+zFbh/T/Vu3aXAidP1\nLEnad+Z6cnwMeE6Se5N8NcmHkxzW1Q4Htgwsv7kbn019c9+4JGlI5hoc64HbgFcBr6P3ltYfd7WD\npli++p5zuvpgb7WHcQCSnN+dYJ/YtGnTzLqXJDWbyTmOPaqqy/ofJ/kd4OokrwV2sfsv+QA7u/vT\n1Wugnu52J1OoqiuBKwHGx8drqmUkSXM339dxbAQOBo6id1J9xUB9OfB4d7+1vry7fRxJ0tDMOjiS\nHJLkwSSn9Q2fSO+I4D/phcgJSZb31U8FNnT3NwKr+7Z3GHD8nurdujuAL822Z0nS3M06OKrqO8Ct\nwPuTPCvJ6cBlwNVVtRP4HL0AuSLJTyS5ADgDuLrbxF8Cq5NcmGQV8J5u+Vu7+jrg/CQv6a79uAz4\n66raPtueJUlzN9e3ql4PfBn4DHAT8E/AbwJU1Q7g5cBJ9C7uuwh4TVXd3dXvBF4D/Ba96zpOA9ZU\n1ZPdtj8AfAT4P8DtwIOT25YkDU+qFt955PHx8ZqYmBh2Gxphu5adPrTnXrLljqE9t7Q3SdZX1fh0\nyznJoSSpicEhSWpicEiSmhgckqQmBockqYnBIUlqYnBIkpoYHJKkJgaHJKmJwSFJamJwSJKaGByS\npCYGhySpicEhSWpicEiSmhgckqQmBockqYnBIUlqYnBIkpoYHJKkJgaHJKmJwSFJamJwSJKaGByS\npCYGhySpicEhSWpicEiSmhgckqQmBockqYnBIUlqYnBIkpoYHJKkJgaHJKmJwSFJamJwSJKaGByS\npCYGhySpicEhSWpicEiSmsw4OJIckeTNSe5LsrRv/Pgkn0nyRJKHklw0sN4LkmxIsiPJ3UleNFC/\nMMmDSbYnuSXJCX21Q5P8WZItSb6Z5KokT5nLDkuS5mZGwZHkXcDXgd8FThgoXwNsA1YDFwKXJHlZ\nt95K4HrgE8AzgeuA65KMdfUXA5cCbwLGgW8B1/Zt+w+A5wEv7H6eC7yzdSclSfNnpkccW4EzgVf1\nDyb5ceCngTdU1YaquppeOJzbLbIGeLSq3l5VXwQuBh7rxgHOA66tqmuragPwRuCnkqzqq19aVf+/\nqm4H/rBv25KkIZhRcFTVO6rq81OUTga2VdUDfWN3Aqv66nf1bae6x3uq3wdsB1YlWQb8cH+92/YP\nJVk+k74lSfNvrifHDwe2DIxt7sbnWp9cZstAjb6aJGk/m2twHDTFWPVtdy71PdVgir6TnJ9kIsnE\npk2b9tq0JGn25hocu6bYRoCd81DfNUWP6W53MqCqrqyq8aoaX7ly5Yx3QJLUZq7BsRVYMTC2HHh8\nHupbu8crBmqw+9tbkqT9ZK7BsRE4NMnJfWOnAhv66s9OsgQgSYBTBuqrJ1dM8gzgqcDGqtoMPNxf\n77b91araiiRpKOYUHN1HbNcD70tySpKzgVcC67pFbgAOAy5PchJwCb0jiE929XXAmiSv7sLnvcDt\nVfXlvvpbk/x8kjOAtX3bliQNwdLpF5nW2cCfAhP0rtFYW1U3A1TVI0leQS8Q3gDcC5xVVd/o6jcl\nWQtcDvwgcBvff53Gxd34p7rHf0UvfCRJQ5LepRWLy/j4eE1MTAy7DY2wXctOH9pzL9lyx9CeW9qb\nJOurany65ZzkUJLUxOCQJDUxOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklSE4NDktTE4JAkNTE4\nJElNDA5JUhODQ5LUxOCQJDUxOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklSE4NDktTE4JAkNTE4\nJElNDA5JUhODQ5LUxOCQJDUxOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklSE4NDktTE4JAkNTE4\nJElNDA5JUhODQ5LUxOCQJDUxOCRJTeYcHElOSVIDP090teOTfCbJE0keSnLRwLovSLIhyY4kdyd5\n0UD9wiQPJtme5JYkJ8y1X0nS3MzHEccY8ChwdN/PsV3tGmAbsBq4ELgkycsAkqwErgc+ATwTuA64\nLslYV38xcCnwJmAc+BZw7Tz0K0mag6XzsI0x4D+q6uH+wSQ/Dvw0cHxVPQBsSPJS4Fzgk8Aa4NGq\nenu3/MXAa7rxDwHnAddW1bVd/Y3AvUlWVdU989C3JGkW5uuI4+Epxk8GtnWhMelOYFVf/a7JQlVV\n93hP9fuA7X11SdIQzFdwnJjk37rzGNckOQo4HNgysOzmbpx5qEuShmA+gmMjcDvwWuAc4H/QO7dx\n0BTLVt9zzrX+fZKcn2QiycSmTZtm3r0kqcmcg6Oq/ryqzquq26vqH4FfB54P7Jpi+wF2dvfnWh/s\n48qqGq+q8ZUrV85qXyRJ09sX13Fs7G5/DFgxUFsOPN7d3zrHuiRpCObjOo4vTH7EtnNid/sJ4NAk\nJ/fVTgU2dPc3As9OsqTbToBTBuqr+57nGcBT+V4wSZKGYD6OOP4euCzJGUlOBf4YuLWqvgisB97X\nXSR4NvBKYF233g3AYcDlSU4CLqF3hPHJrr4OWJPk1V34vBe4vaq+PA89S5JmaT6C4/eBm+ldzPcP\nwGPAq7ra2fROck/Q+8W/tqpuBqiqR4BXAC+h97HbXwbOqqpvdPWbgLXA5cAXgKfRuwZEkjRE6V0+\nsbiMj4/XxMTEsNvQCNu17PShPfeSLXcM7bmlvUmyvqrGp1vOSQ4lSU0MDklSE4NDktTE4JAkNTE4\nJElNDA5JUhODQ5LUxOCQJDUxOCRJTQwOSVKT+fjOcWnWhjn1h6TZ8YhDktTE4JAkNTE4JElNDA5J\nUhODQ5LUxOCQJDUxOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklSE4NDktTE4JAkNTE4JElNDA5J\nUhODQ5LUxOCQJDUxOCRJTQwOSVKTpcNuQDrQ7Fp2+lCed8mWO4byvFp8POKQJDUxOCRJTQwOSVIT\ng0OS1MTgkCQ1MTgkSU0MDklSk5EPjiRHJLkuybeSPJrk3UlGvm9JWqwWwgWAHwR+BHgOMAb8X+Ar\nwPuH2ZQkHahG+i/3JE8D1gBvqap/raq/oxck5w63M0k6cI36EceJwMHAXX1jdwK/OZx2FqdhTYEh\naWEa9eA4vLvd0je2uW9c0gw5R5bmy6gHx0FTjBWQwcEk5wPndw+3JfnivmxsHzsSeHTYTcwD92O0\nDGc/stvLda4Ww7/HqO7DsTNZaNSDY1d3238uJsB3BxesqiuBK/dHU/takomqGh92H3PlfowW92N0\nLPR9GOmT48DW7nZF39hy4PEh9CJJYvSD415gJ7C6b+xUYMNw2pEkjfRbVVW1LcmNwGVJHgaOAC4A\n3jbczva5RfGWG+7HqHE/RseC3odU1bB72KskRwIfAV4IbO/uv7VGvXFJWqRGPjgkSaNl1M9xHJCS\nHJvkhiSPJXkwyXuS/MCw+5qNbq6xNye5L8lIvzU6aLHMk7aQ/w0mLZbXRJIfTXJ9kseTPJBkbTL/\nn1fe1xbkf6LFLMnBwKeBfwN+Fjia3vxcW4G3D7G1ZkneBfwW8E3gqCG3MxsLfp60RfBvsGheE90f\nHTcC9wM/Q++aib8EvgZ8bIitNfOtqhGT5LnAZ4EVVbW1G/s94KyqWr3XlUdMkouBz9G7kPMW4OCq\n2jnUpmaomydtM3BmVX2uG7sU+J9VdcYwe2uxkP8NJi2W10SSn6QXfkdX1cPd2AeAI6vq7KE212jB\nHXYfAO4H1ky+QDo7gCeH1M+sVdU7qurzw+5jlvY0T9qq4bQzOwv832DSYnlN3AM8fTI0Ok8CTxtS\nP7PmW1Ujpqq+Ru/QFfjvw9vzgHVDa+rA5DxpI2KxvCaq6rvAtsnHSU6jN9P364fW1CwZHEOS5BB2\nP+KrqtoxMPYWer+srtgvjTVq2I+FZsbzpGm/G+nXxHSS/DLwceBQ4KNVdd2QW2rmW1XD8wV616X0\n/3zfxIxJzqR3sePZVbV9v3c4M9PuxwI143nStP8skNfEdP4OOA14JfCSJBcMuZ9mHnEMSVWdsrd6\nkhOBq4HXVdXE/umq3XT7sYD1z5P2SHffedKGaKG8JqZTVdvo/XH1xW6fLqD3Cb4FwyOOEZTk6fQ+\ntvfBqvr4sPs5QDlP2ghZDK+JJM9PctfAtUDfpXeif0HxiGPEdBcDfYzeX7lXJBnrK29ZwIfnC8oB\nPE/ayFlEr4k76V0P9N4k7wd+lN63mX5gqF3NgsExeo4BXt7df2ig9mvAVfu1mwPb6+nNjXYr35sn\n7SND7ejAtCheE1X1WJIXAe8G/pnep/Q+CvzRUBubBS8AlCQ18RyHJKmJwSFJamJwSJKaGBySpCYG\nhySpicEhSSNotl/AleSQJOcmuTXJLw7UnpakpvgZ29P2puJ1HJI0Ymb7BVxJzgHe1z08it0n5Ty6\nuz0eeKJv/D9b+jM4JGn0bAXO5HtfwDVThwC/DVzP1FOZjAFbq+qBuTTnW1WSNGL29gVcSY5K8tdJ\ntia5N8nr+tb7i6q6pqq+s4dNjwEP76E2YwaHJC0QSQ4C/obeW1irgTcClw+ey9iLMWBZkokkjyT5\nmyQntPZhcEjSwvELwDOA11bVv1fVp+hNAHneDNd/ALgNuAh4Gb2vR/50y8l38ByHJC0kpwHLgM29\nSYOB3nmNGX2vfFXdBNw0+TjJufTeunoO8I8zbcLgkKSF5V7gpQNjs5pavqo2JdlEb4r3GTM4JGnh\nuBs4lt73kGwCSPIUYE8nw79P9x0zN1fVn3SPlwFHsvt09XvlOQ5JWjj+lt4Rx9VJnp3kWd3Ybzes\n/7Ykv5jkJODDwFeA/9fShMEhSQtEVX0X+CXg2/ROcn+W3jcLfmiGm/gQvW8c/CjwT/S+2fLFe/n4\n7pT8IidJUhOPOCRJTQwOSVITg0OS1MTgkCQ1MTgkSU0MDklSE4NDktTE4JAkNTE4JElN/gthPlQ8\nV68+dgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f612ee623c8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(np.linalg.inv(full_S).flatten())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.],\n",
+       "       [0.]])"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(XBfinal).sum(axis=1).reshape(-1,1) - fullmod.predy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (Analysis)",
+   "language": "python",
+   "name": "ana"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/gwr/sel_bw.py
+++ b/gwr/sel_bw.py
@@ -8,6 +8,7 @@ __author__ = "Taylor Oshan Tayoshan@gmail.com"
 
 import numpy as np
 from scipy.spatial.distance import pdist, squareform
+from scipy.optimize import minimize_scalar
 from pysal.common import KDTree
 import pysal.spreg.user_output as USER
 from spglm.family import Gaussian, Poisson, Binomial
@@ -195,14 +196,16 @@ class Sel_BW(object):
             else:
                 raise TypeError('Unsupported kernel function ', self.kernel)
 
-        function = lambda bw: GWR(self.coords, self.y, self.X_loc, bw, family=self.family,
+        def function(bw):
+            return GWR(self.coords, self.y, self.X_loc, bw, family=self.family,
                     kernel=self.kernel, fixed=self.fixed, offset=self.offset).fit(final=False)[self.criterion]
+
 
         if ktype % 2 == 0:
             int_score = True
         else:
             int_score = False
-        self.int_score = int_score
+        self.int_score = int_score #isn't this just self.fixed?
 
         self._bw()
 
@@ -210,8 +213,11 @@ class Sel_BW(object):
 
     def _bw(self):
         #gwr_func = lambda bw: getDiag[self.criterion](GWR(self.coords, self.y, self.X_loc, bw, family=self.family, kernel=self.kernel, fixed=self.fixed, constant=self.constant).fit())
-        gwr_func = lambda bw: GWR(self.coords, self.y, self.X_loc, bw, family=self.family,
+        def gwr_func(bw):
+            return GWR(self.coords, self.y, self.X_loc, bw, family=self.family,
                         kernel=self.kernel, fixed=self.fixed, constant=self.constant,offset=self.offset).fit(final=False)[self.criterion]
+
+        self._optimized_function = gwr_func
         if self.search == 'golden_section':
             a,c = self._init_section(self.X_glob, self.X_loc, self.coords,
                     self.constant)
@@ -221,9 +227,15 @@ class Sel_BW(object):
         elif self.search == 'interval':
             self.bw = equal_interval(self.bw_min, self.bw_max, self.interval,
                     gwr_func, self.int_score)
+        elif self.search == 'scipy':
+            if self.bw_min == self.bw_max == 0:
+                self.bw_min, self.bw_max = self._init_section(self.X_glob, self.X_loc, self.coords, self.constant)
+            elif self.bw_min == self.bw_max:
+                raise Exception("Minimum bandwidth and maximum bandwidth must be distinct for scipy solver.")
+            self._optimize_result = minimize_scalar(gwr_func, bounds=(self.bw_min,self.bw_max), method='bounded')
+            self.bw = [np.round(self._optimize_result.x) if not self.fixed else self._optimize_result.x]
         else:
             raise TypeError('Unsupported computational search method ', search)
-
 
     def _init_section(self, X_glob, X_loc, coords, constant):
         if len(X_glob) > 0:
@@ -244,13 +256,9 @@ class Sel_BW(object):
             a = 40 + 2 * n_vars
             c = n
         else:
-            nn = 40 + 2 * n_vars
-            sq_dists = squareform(pdist(coords))
-            sort_dists = np.sort(sq_dists, axis=1)
-            min_dists = sort_dists[:,nn-1]
-            max_dists = sort_dists[:,-1]
-            a = np.min(min_dists)/2.0
-            c = np.max(max_dists)/2.0
+            sq_dists = pdist(coords)
+            a = np.min(sq_dists)/2.0
+            c = np.max(sq_dists)*2.0
 
         if a < self.bw_min:
             a = self.bw_min

--- a/mgwr/__init__.py
+++ b/mgwr/__init__.py
@@ -1,0 +1,4 @@
+from . import gwr
+from . import sel_bw
+from . import diagnostics
+from . import kernels

--- a/mgwr/data.py
+++ b/mgwr/data.py
@@ -1,0 +1,11 @@
+def georgia():
+    import pysal as ps
+    import geopandas as gpd
+    import pandas as pd
+    import shapely.geometry as geom
+
+    data = pd.read_csv(ps.examples.get_path('GData_utm.csv'))
+    data['geometry'] = [geom.Point(x,y) for x,y in data[['X','Y']].values]
+    data = gpd.GeoDataFrame(data)
+
+    return data

--- a/mgwr/diagnostics.py
+++ b/mgwr/diagnostics.py
@@ -1,0 +1,81 @@
+"""
+Diagnostics for estimated gwr modesl
+"""
+__author__ = "Taylor Oshan tayoshan@gmail.com"
+
+import numpy as np
+from pysal.contrib.glm.family import Gaussian, Poisson, Binomial
+
+def get_AICc(gwr):
+    """
+    Get AICc value
+    
+    Gaussian: p61, (2.33), Fotheringham, Brunsdon and Charlton (2002)
+    
+    GWGLM: AICc=AIC+2k(k+1)/(n-k-1), Nakaya et al. (2005): p2704, (36)
+
+    """
+    n = gwr.n
+    k = gwr.tr_S
+    if isinstance(gwr.family, Gaussian):
+        aicc = -2.0*gwr.llf + 2.0*n*(k + 1.0)/(n-k-2.0)  
+    elif isinstance(gwr.family, (Poisson, Binomial)):
+        aicc = get_AIC(gwr) + 2.0 * k * (k+1.0) / (n - k - 1.0) 
+    return aicc
+
+def get_AIC(gwr):
+    """
+    Get AIC calue
+
+    Gaussian: p96, (4.22), Fotheringham, Brunsdon and Charlton (2002)
+
+    GWGLM:  AIC(G)=D(G) + 2K(G), where D and K denote the deviance and the effective
+    number of parameters in the model with bandwidth G, respectively.
+    
+    """   
+    k = gwr.tr_S
+    #deviance = -2*log-likelihood
+    y = gwr.y
+    mu = gwr.mu
+    if isinstance(gwr.family, Gaussian):
+        aic = -2.0 * gwr.llf + 2.0 * (k+1)
+    elif isinstance(gwr.family, (Poisson, Binomial)):
+        aic = np.sum(gwr.family.resid_dev(y, mu)**2) + 2.0 * k
+    return aic 
+
+def get_BIC(gwr):
+    """
+    Get BIC value
+
+    Gaussian: p61 (2.34), Fotheringham, Brunsdon and Charlton (2002)
+    BIC = -2log(L)+klog(n)
+
+    GWGLM: BIC = dev + tr_S * log(n)
+
+    """
+    n = gwr.n      # (scalar) number of observations
+    k = gwr.tr_S  
+    y = gwr.y
+    mu = gwr.mu
+    if isinstance(gwr.family, Gaussian):
+        bic = -2.0 * gwr.llf + (k+1) * np.log(n) 
+    elif isinstance(gwr.family, (Poisson, Binomial)):
+        bic = np.sum(gwr.family.resid_dev(y, mu)**2) + k * np.log(n)
+    return bic
+
+def get_CV(gwr):
+    """
+    Get CV value
+
+    Gaussian only
+
+    Methods: p60, (2.31) or p212 (9.4)
+    Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+    Geographically weighted regression: the analysis of spatially varying relationships.
+    Modification: sum of residual squared is divided by n according to GWR4 results
+
+    """
+    aa = gwr.resid_response.reshape((-1,1))/(1.0-gwr.influ)
+    cv = np.sum(aa**2)/gwr.n
+    return cv
+

--- a/mgwr/gwr.py
+++ b/mgwr/gwr.py
@@ -1028,6 +1028,7 @@ class MGWR(GWR):
         self.kernel = kernel
         self.fixed = fixed
         self.constant = constant
+        self.models = []
         if constant:
           self.X = USER.check_constant(self.X)
 
@@ -1063,6 +1064,7 @@ class MGWR(GWR):
             results = model.fit(ini_params, tol, max_iter, solve)
             params[:,i] = results.params.flatten()
             err = results.resid_response.reshape((-1,1))
+            self.models.append(results)
         return MGWRResults(self, params)
 
 class MGWRResults(object):

--- a/mgwr/gwr.py
+++ b/mgwr/gwr.py
@@ -1,0 +1,1128 @@
+#Main GWR classes
+
+#Offset does not yet do anyhting and needs to be implemented
+
+__author__ = "Taylor Oshan Tayoshan@gmail.com"
+
+import numpy as np
+import numpy.linalg as la
+from scipy.stats import t
+from .kernels import *
+from .diagnostics import get_AIC, get_AICc, get_BIC
+import pysal.spreg.user_output as USER
+from pysal.contrib.glm.family import Gaussian, Binomial, Poisson
+from pysal.contrib.glm.glm import GLM, GLMResults
+from pysal.contrib.glm.iwls import iwls
+from pysal.contrib.glm.utils import cache_readonly
+
+fk = {'gaussian': fix_gauss, 'bisquare': fix_bisquare, 'exponential': fix_exp}
+ak = {'gaussian': adapt_gauss, 'bisquare': adapt_bisquare, 'exponential': adapt_exp}
+
+class GWR(GLM):
+    """
+    Geographically weighted regression. Can currently estimate Gaussian,
+    Poisson, and logistic models(built on a GLM framework). GWR object prepares
+    model input. Fit method performs estimation and returns a GWRResults object.
+
+    Parameters
+    ----------
+        coords        : array-like
+                        n*2, collection of n sets of (x,y) coordinates of
+                        observatons; also used as calibration locations is
+                        'points' is set to None
+
+        y             : array
+                        n*1, dependent variable
+
+        X             : array
+                        n*k, independent variable, exlcuding the constant
+
+        bw            : scalar
+                        bandwidth value consisting of either a distance or N
+                        nearest neighbors; user specified or obtained using
+                        Sel_BW
+
+        family        : family object
+                        underlying probability model; provides
+                        distribution-specific calculations
+
+        offset        : array
+                        n*1, the offset variable at the ith location. For Poisson model
+                        this term is often the size of the population at risk or
+                        the expected size of the outcome in spatial epidemiology
+                        Default is None where Ni becomes 1.0 for all locations;
+                        only for Poisson models
+
+        sigma2_v1     : boolean
+                        specify sigma squared, True to use n as denominator;
+                        default is False which uses n-k
+
+        kernel        : string
+                        type of kernel function used to weight observations;
+                        available options:
+                        'gaussian'
+                        'bisquare'
+                        'exponential'
+
+        fixed         : boolean
+                        True for distance based kernel function and  False for
+                        adaptive (nearest neighbor) kernel function (default)
+
+        constant      : boolean
+                        True to include intercept (default) in model and False to exclude
+                        intercept.
+
+    Attributes
+    ----------
+        coords        : array-like
+                        n*2, collection of n sets of (x,y) coordinates used for
+                        calibration locations
+
+        y             : array
+                        n*1, dependent variable
+
+        X             : array
+                        n*k, independent variable, exlcuding the constant
+
+        bw            : scalar
+                        bandwidth value consisting of either a distance or N
+                        nearest neighbors; user specified or obtained using
+                        Sel_BW
+
+        family        : family object
+                        underlying probability model; provides
+                        distribution-specific calculations
+
+        offset        : array
+                        n*1, the offset variable at the ith location. For Poisson model
+                        this term is often the size of the population at risk or
+                        the expected size of the outcome in spatial epidemiology
+                        Default is None where Ni becomes 1.0 for all locations
+
+        sigma2_v1     : boolean
+                        specify sigma squared, True to use n as denominator;
+                        default is False which uses n-k
+
+        kernel        : string
+                        type of kernel function used to weight observations;
+                        available options:
+                        'gaussian'
+                        'bisquare'
+                        'exponential'
+
+        fixed         : boolean
+                        True for distance based kernel function and  False for
+                        adaptive (nearest neighbor) kernel function (default)
+
+        constant      : boolean
+                        True to include intercept (default) in model and False to exclude
+                        intercept
+
+        n             : integer
+                        number of observations
+
+        k             : integer
+                        number of independent variables
+
+        mean_y        : float
+                        mean of y
+
+        std_y         : float
+                        standard deviation of y
+
+        fit_params    : dict
+                        parameters passed into fit method to define estimation
+                        routine
+
+        W             : array
+                        n*n, spatial weights matrix for weighting all
+                        observations from each calibration point
+        points        : array-like
+                        n*2, collection of n sets of (x,y) coordinates used for
+                        calibration locations instead of all observations;
+                        defaults to None unles specified in predict method
+        P             : array
+                        n*k, independent variables used to make prediction;
+                        exlcuding the constant; default to None unless specified
+                        in predict method
+        exog_scale    : scalar
+                        estimated scale using sampled locations; defualt is None
+                        unless specified in predict method
+        exog_resid    : array-like
+                        estimated residuals using sampled locations; defualt is None
+                        unless specified in predict method
+
+    Examples
+    --------
+    #basic model calibration
+
+    >>> import pysal
+    >>> from pysal.contrib.gwr.gwr import GWR
+    >>> data = pysal.open(pysal.examples.get_path('GData_utm.csv'))
+    >>> coords = zip(data.bycol('X'), data.by_col('Y')) 
+    >>> y = np.array(data.by_col('PctBach')).reshape((-1,1))
+    >>> rural = np.array(data.by_col('PctRural')).reshape((-1,1))
+    >>> pov = np.array(data.by_col('PctPov')).reshape((-1,1))
+    >>> african_amer = np.array(data.by_col('PctBlack')).reshape((-1,1))
+    >>> X = np.hstack([rural, pov, african_amer])
+    >>> model = GWR(coords, y, X, bw=90.000, fixed=False, kernel='bisquare')
+    >>> results = model.fit()
+    >>> print results.params.shape
+    (159, 4)
+
+    #predict at unsampled locations
+    
+    >>> index = np.arange(len(self.y))
+    >>> test = index[-10:]
+    >>> X_test = X[test]
+    >>> coords_test = list(coords[test])
+    >>> model = GWR(coords, y, X, bw=94, fixed=False, kernel='bisquare')
+    >>> results = model.predict(coords_test, X_test)
+    >>> print results.params.shape
+    (10, 4)
+
+    """
+    def __init__(self, coords, y, X, bw, family=Gaussian(), offset=None,
+            sigma2_v1=False, kernel='bisquare', fixed=False, constant=True):
+        """
+        Initialize class
+        """
+        GLM.__init__(self, y, X, family, constant=constant)
+        self.constant = constant
+        self.sigma2_v1 = sigma2_v1
+        self.coords = coords
+        self.bw = bw
+        self.kernel = kernel
+        self.fixed = fixed
+        if offset is None:
+          self.offset = np.ones((self.n, 1))
+        else:
+            self.offset = offset * 1.0
+        self.fit_params = {}
+        self.W = self._build_W(fixed, kernel, coords, bw)
+        self.points = None
+        self.exog_scale = None
+        self.exog_resid = None
+        self.P = None
+
+    def _build_W(self, fixed, kernel, coords, bw, points=None):
+        if fixed:
+            try:
+              W = fk[kernel](coords, bw, points)
+            except:
+                raise #TypeError('Unsupported kernel function  ', kernel)
+        else:
+            try:
+                W = ak[kernel](coords, bw, points)
+            except:
+                raise #TypeError('Unsupported kernel function  ', kernel)
+
+        return W
+
+    def fit(self, ini_params=None, tol=1.0e-5, max_iter=20, solve='iwls'):
+        """
+        Method that fits a model with a particular estimation routine.
+
+        Parameters
+        ----------
+
+        ini_betas     : array
+                        k*1, initial coefficient values, including constant.
+                        Default is None, which calculates initial values during
+                        estimation
+        tol:            float
+                        Tolerence for estimation convergence
+        max_iter      : integer
+                        Maximum number of iterations if convergence not
+                        achieved
+        solve         : string
+                        Technique to solve MLE equations.
+                        'iwls' = iteratively (re)weighted least squares (default)
+        """
+        self.fit_params['ini_params'] = ini_params
+        self.fit_params['tol'] = tol
+        self.fit_params['max_iter'] = max_iter
+        self.fit_params['solve']= solve
+        if solve.lower() == 'iwls':
+            m = self.W.shape[0]
+            params = np.zeros((m, self.k))
+            predy = np.zeros((m, 1))
+            v = np.zeros((m, 1))
+            w = np.zeros((m, 1))
+            z = np.zeros((m, self.n))
+            S = np.zeros((m, self.n))
+            R = np.zeros((m, self.n))
+            CCT = np.zeros((m, self.k))
+            #f = np.zeros((n, n))
+            p = np.zeros((m, 1))
+            for i in range(m):
+                wi = self.W[i].reshape((-1,1))
+                rslt = iwls(self.y, self.X, self.family, self.offset, None,
+                    ini_params, tol, max_iter, wi=wi)
+                params[i,:] = rslt[0].T
+                predy[i] = rslt[1][i]
+                v[i] = rslt[2][i]
+                w[i] = rslt[3][i]
+                z[i] = rslt[4].flatten()
+                R[i] = np.dot(self.X[i], rslt[5])
+                ri = np.dot(self.X[i], rslt[5])
+                S[i] = ri*np.reshape(rslt[4].flatten(), (1,-1))
+                #dont need unless f is explicitly passed for
+                #prediction of non-sampled points
+                #cf = rslt[5] - np.dot(rslt[5], f)
+                #CCT[i] = np.diag(np.dot(cf, cf.T/rslt[3]))
+                CCT[i] = np.diag(np.dot(rslt[5], rslt[5].T))
+            S = S * (1.0/z)
+        return GWRResults(self, params, predy, S, CCT, w)
+
+    def predict(self, points, P, exog_scale=None, exog_resid=None, fit_params={}):
+        """
+        Method that predicts values of the dependent variable at un-sampled
+        locations
+
+        Parameters
+        ----------
+        points        : array-like
+                        n*2, collection of n sets of (x,y) coordinates used for
+                        calibration prediction locations
+        P             : array
+                        n*k, independent variables used to make prediction;
+                        exlcuding the constant
+        exog_scale    : scalar
+                        estimated scale using sampled locations; defualt is None
+                        which estimates a model using points from "coords"
+        exog_resid    : array-like
+                        estimated residuals using sampled locations; defualt is None
+                        which estimates a model using points from "coords"; if
+                        given it must be n*1 where n is the length of coords
+        fit_params    : dict
+                        key-value pairs of parameters that will be passed into fit 
+                        method to define estimation routine; see fit method for more details
+
+        """
+        if (exog_scale is None) & (exog_resid is None):
+            train_gwr = self.fit(**fit_params)
+            self.exog_scale = train_gwr.scale
+            self.exog_resid = train_gwr.resid_response
+        elif (exog_scale is not None) & (exog_resid is not None):
+            self.exog_scale = exog_scale
+            self.exog_resid = exog_resid
+        else:
+            raise InputError('exog_scale and exog_resid must both either be'
+                    'None or specified')
+        self.points = points
+        if self.constant:
+            P = np.hstack([np.ones((len(P),1)), P])
+            self.P = P
+        else:
+            self.P = P
+        self.W = self._build_W(self.fixed, self.kernel, self.coords, self.bw, points)
+        gwr = self.fit(**fit_params)
+
+        return gwr
+
+    @cache_readonly
+    def df_model(self):
+        raise NotImplementedError('Only computed for fitted model in GWRResults')
+
+    @cache_readonly
+    def df_resid(self):
+        raise NotImplementedError('Only computed for fitted model in GWRResults')
+
+class GWRResults(GLMResults):
+    """
+    Basic class including common properties for all GWR regression models
+
+    Parameters
+    ----------
+        model               : GWR object
+                            pointer to GWR object with estimation parameters
+
+        params              : array
+                              n*k, estimated coefficients
+
+        predy               : array
+                              n*1, predicted y values
+
+        w                   : array
+                              n*1, final weight used for iteratively re-weighted least
+                              sqaures; default is None
+
+        S                   : array
+                              n*n, hat matrix
+
+        CCT                 : array
+                              n*k, scaled variance-covariance matrix
+
+    Attributes
+    ----------
+        model               : GWR Object
+                              points to GWR object for which parameters have been
+                              estimated
+
+        params              : array
+                              n*k, parameter estimates
+
+        predy               : array
+                              n*1, predicted value of y
+
+        y                   : array
+                              n*1, dependent variable
+
+        X                   : array
+                              n*k, independent variable, including constant
+
+        family              : family object
+                              underlying probability model; provides
+                              distribution-specific calculations
+
+        n                   : integer
+                              number of observations
+
+        k                   : integer
+                              number of independent variables
+
+        df_model            : integer
+                              model degrees of freedom
+
+        df_resid            : integer
+                              residual degrees of freedom
+
+        offset              : array
+                              n*1, the offset variable at the ith location.
+                              For Poisson model this term is often the size of
+                              the population at risk or the expected size of
+                              the outcome in spatial epidemiology; Default is
+                              None where Ni becomes 1.0 for all locations
+
+        scale               : float
+                              sigma squared used for subsequent computations
+
+        w                   : array
+                              n*1, final weights from iteratively re-weighted least
+                              sqaures routine
+
+        resid_response      : array
+                              n*1, residuals of the repsonse
+
+        resid_ss            : scalar
+                              residual sum of sqaures
+
+        W                   : array
+                              n*n; spatial weights for each observation from each
+                              calibration point
+
+        S                   : array
+                              n*n, hat matrix
+
+        CCT                 : array
+                              n*k, scaled variance-covariance matrix
+
+        tr_S                : float
+                              trace of S (hat) matrix
+
+        tr_STS              : float
+                              trace of STS matrix
+
+        tr_SWSTW            : float
+                              trace of weighted STS matrix; weights are those output
+                              from iteratively weighted least sqaures (not spatial
+                              weights)
+
+        y_bar               : array
+                              n*1, weighted mean value of y
+
+        TSS                 : array
+                              n*1, geographically weighted total sum of squares
+
+        RSS                 : array
+                              n*1, geographically weighted residual sum of squares
+
+        localR2             : array
+                              n*1, local R square
+
+        sigma2_v1           : float
+                              sigma squared, use (n-v1) as denominator
+
+        sigma2_v1v2         : float
+                              sigma squared, use (n-2v1+v2) as denominator
+
+        sigma2_ML           : float
+                              sigma squared, estimated using ML
+
+        std_res             : array
+                              n*1, standardised residuals
+
+        bse                 : array
+                              n*k, standard errors of parameters (betas)
+
+        influ               : array
+                              n*1, leading diagonal of S matrix
+
+        CooksD              : array
+                              n*1, Cook's D
+
+        tvalues             : array
+                              n*k, local t-statistics
+
+        adj_alpha           : array
+                              3*1, corrected alpha values to account for multiple
+                              hypothesis testing for the 90%, 95%, and 99% confidence
+                              levels; tvalues with an absolute value larger than the
+                              corrected alpha are considered statistically
+                              significant.
+
+        deviance            : array
+                              n*1, local model deviance for each calibration point
+
+        resid_deviance      : array
+                              n*1, local sum of residual deviance for each
+                              calibration point
+
+        llf                 : scalar
+                              log-likelihood of the full model; see
+                              pysal.contrib.glm.family for damily-sepcific
+                              log-likelihoods
+
+        pDev                : float
+                              local percent of deviation accounted for; analogous to
+                              r-squared for GLM's
+
+        mu                  : array
+                              n*, flat one dimensional array of predicted mean
+                              response value from estimator
+
+        fit_params          : dict
+                              parameters passed into fit method to define estimation
+                              routine
+    """
+    def __init__(self, model, params, predy, S, CCT, w=None):
+        GLMResults.__init__(self, model, params, predy, w)
+        self.W = model.W
+        self.offset = model.offset
+        if w is not None:
+            self.w = w
+        self.predy = predy
+        self.S = S
+        self.CCT = self.cov_params(CCT, model.exog_scale)
+        self._cache = {}
+
+    @cache_readonly
+    def resid_ss(self):
+        if self.model.points is not None:
+            raise NotImplementedError('Not available for GWR prediction')
+        else:
+            u = self.resid_response.flatten()
+        return np.dot(u, u.T)
+
+    @cache_readonly
+    def scale(self, scale=None):
+        if isinstance(self.family, Gaussian):
+            if self.model.sigma2_v1:
+                scale = self.sigma2_v1
+            else:
+                scale = self.sigma2_v1v2
+        else:
+            scale = 1.0
+        return scale
+
+    def cov_params(self, cov, exog_scale=None):
+        """
+        Returns scaled covariance parameters
+        Parameters
+        ----------
+        cov         : array
+                      estimated covariance parameters
+
+        Returns
+        -------
+        Scaled covariance parameters
+
+        """
+        if exog_scale is not None:
+          return cov*exog_scale
+        else:
+            return cov*self.scale
+
+    @cache_readonly
+    def tr_S(self):
+        """
+        trace of S (hat) matrix
+        """
+        return np.trace(self.S*self.w)
+
+    @cache_readonly
+    def tr_STS(self):
+        """
+        trace of STS matrix
+        """
+        return np.trace(np.dot(self.S.T*self.w,self.S*self.w))
+
+    @cache_readonly
+    def y_bar(self):
+        """
+        weighted mean of y
+        """
+        if self.model.points is not None:
+          n = len(self.model.points)
+        else:
+            n = self.n
+        off = self.offset.reshape((-1,1))
+        arr_ybar = np.zeros(shape=(self.n,1))
+        for i in range(n):
+            w_i= np.reshape(np.array(self.W[i]), (-1, 1))
+            sum_yw = np.sum(self.y.reshape((-1,1)) * w_i)
+            arr_ybar[i] = 1.0 * sum_yw / np.sum(w_i*off)
+        return arr_ybar
+
+    @cache_readonly
+    def TSS(self):
+        """
+        geographically weighted total sum of squares
+
+        Methods: p215, (9.9)
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+
+        """
+        if self.model.points is not None:
+          n = len(self.model.points)
+        else:
+            n = self.n
+        TSS = np.zeros(shape=(n,1))
+        for i in range(n):
+          TSS[i] = np.sum(np.reshape(np.array(self.W[i]), (-1,1)) *
+                  (self.y.reshape((-1,1)) - self.y_bar[i])**2)
+        return TSS
+
+    @cache_readonly
+    def RSS(self):
+        """
+        geographically weighted residual sum of squares
+
+        Methods: p215, (9.10)
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+        """
+        if self.model.points is not None:
+          n = len(self.model.points)
+          resid = self.model.exog_resid.reshape((-1,1))
+        else:
+            n = self.n
+            resid = self.resid_response.reshape((-1,1))
+        RSS = np.zeros(shape=(n,1))
+        for i in range(n):
+            RSS[i] = np.sum(np.reshape(np.array(self.W[i]), (-1,1))
+                  * resid**2)
+        return RSS
+
+    @cache_readonly
+    def localR2(self):
+        """
+        local R square
+
+        Methods: p215, (9.8)
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+        """
+        if isinstance(self.family, Gaussian):
+            return (self.TSS - self.RSS)/self.TSS
+        else:
+            raise NotImplementedError('Only applicable to Gaussian')
+
+    @cache_readonly
+    def sigma2_v1(self):
+        """
+        residual variance
+
+        Methods: p214, (9.6),
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+
+        only use v1
+        """
+        return (self.resid_ss/(self.n-self.tr_S))
+
+    @cache_readonly
+    def sigma2_v1v2(self):
+        """
+        residual variance
+
+        Methods: p55 (2.16)-(2.18)
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+
+        use v1 and v2 #used in GWR4
+        """
+        if isinstance(self.family, (Poisson, Binomial)):
+            return self.resid_ss/(self.n - 2.0*self.tr_S +
+                  self.tr_STS) #could be changed to SWSTW - nothing to test against
+        else:
+            return self.resid_ss/(self.n - 2.0*self.tr_S +
+                  self.tr_STS) #could be changed to SWSTW - nothing to test against
+    @cache_readonly
+    def sigma2_ML(self):
+        """
+        residual variance
+
+        Methods: maximum likelihood
+        """
+        return self.resid_ss/self.n
+
+    @cache_readonly
+    def std_res(self):
+        """
+        standardized residuals
+
+        Methods:  p215, (9.7)
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+        """
+        return self.resid_response.reshape((-1,1))/(np.sqrt(self.scale * (1.0 - self.influ)))
+
+    @cache_readonly
+    def bse(self):
+        """
+        standard errors of Betas
+
+        Methods:  p215, (2.15) and (2.21)
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+        """
+        return np.sqrt(self.CCT)
+
+    @cache_readonly
+    def influ(self):
+        """
+        Influence: leading diagonal of S Matrix
+        """
+        return np.reshape(np.diag(self.S),(-1,1))
+
+    @cache_readonly
+    def cooksD(self):
+        """
+        Influence: leading diagonal of S Matrix
+
+        Methods: p216, (9.11),
+        Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+        Geographically weighted regression: the analysis of spatially varying
+        relationships.
+        Note: in (9.11), p should be tr(S), that is, the effective number of parameters
+        """
+        return self.std_res**2 * self.influ / (self.tr_S * (1.0-self.influ))
+
+    @cache_readonly
+    def deviance(self):
+        off = self.offset.reshape((-1,1)).T
+        y = self.y
+        ybar = self.y_bar
+        if isinstance(self.family, Gaussian):
+          raise NotImplementedError('deviance not currently used for Gaussian')
+        elif isinstance(self.family, Poisson):
+            dev = np.sum(2.0*self.W*(y*np.log(y/(ybar*off))-(y-ybar*off)),axis=1)
+        elif isinstance(self.family, Binomial):
+            dev = self.family.deviance(self.y, self.y_bar, self.W, axis=1)
+        return dev.reshape((-1,1))
+
+    @cache_readonly
+    def resid_deviance(self):
+        if isinstance(self.family, Gaussian):
+          raise NotImplementedError('deviance not currently used for Gaussian')
+        else:
+            off = self.offset.reshape((-1,1)).T
+            y = self.y
+            ybar = self.y_bar
+            global_dev_res = ((self.family.resid_dev(self.y, self.mu))**2)
+            dev_res = np.repeat(global_dev_res.flatten(),self.n)
+            dev_res = dev_res.reshape((self.n, self.n))
+            dev_res = np.sum(dev_res * self.W.T, axis=0)
+            return dev_res.reshape((-1,1))
+
+    @cache_readonly
+    def pDev(self):
+        """
+        Local percentage of deviance accounted for. Described in the GWR4
+        manual. Equivalent to 1 - (deviance/null deviance)
+        """
+        if isinstance(self.family, Gaussian):
+          raise NotImplementedError('Not implemented for Gaussian')
+        else:
+            return 1.0 - (self.resid_deviance/self.deviance)
+
+    @cache_readonly
+    def adj_alpha(self):
+        """
+        Corrected alpha (critical) values to account for multiple testing during hypothesis
+        testing. Includes corrected value for 90% (.1), 95% (.05), and 99%
+        (.01) confidence levels. Correction comes from:
+
+        da Silva, A. R., & Fotheringham, A. S. (2015). The Multiple Testing Issue in
+        Geographically Weighted Regression. Geographical Analysis.
+
+        """
+        alpha = np.array([.1, .05, .001])
+        pe = (2.0 * self.tr_S) - self.tr_STS
+        p = self.k
+        return (alpha*p)/pe
+
+    def filter_tvals(self, alpha):
+        """
+        Utility function to set tvalues with an absolute value smaller than the
+        absolute value of the alpha (critical) value to 0
+
+        Parameters
+        ----------
+        alpha           : scalar
+                          critical value to determine which tvalues are
+                          associated with statistically significant parameter
+                          estimates
+
+        Returns
+        -------
+        filtered       : array
+                          n*k; new set of n tvalues for each of k variables
+                          where absolute tvalues less than the absolute value of
+                          alpha have been set to 0.
+        """
+        alpha = np.abs(alpha)/2.0
+        n = self.n
+        critical = t.ppf(1-alpha, n-1)
+        subset = (self.tvalues < critical) & (self.tvalues > -1.0*critical)
+        tvalues = self.tvalues.copy()
+        tvalues[subset] = 0
+        return tvalues
+
+    @cache_readonly
+    def df_model(self):
+        return self.n - self.tr_S
+
+    @cache_readonly
+    def df_resid(self):
+        return self.n - 2.0*self.tr_S + self.tr_STS
+
+    @cache_readonly
+    def normalized_cov_params(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def resid_pearson(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def resid_working(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def resid_anscombe(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def pearson_chi2(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def null(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def llnull(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def null_deviance(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def aic(self):
+        return get_AIC(self)
+
+    @cache_readonly
+    def aicc(self):
+        return get_AICc(self)
+
+    @cache_readonly
+    def bic(self):
+        return get_BIC(self)
+
+    @cache_readonly
+    def D2(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def adj_D2(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def pseudoR2(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def adj_pseudoR2(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def pvalues(self):
+        raise NotImplementedError('Not implemented for GWR')
+
+    @cache_readonly
+    def predictions(self):
+        P = self.model.P
+        if P is None:
+          raise NotImplementedError('predictions only avaialble if predict'
+          'method called on GWR model')
+        else:
+            predictions = np.sum(P*self.params, axis=1).reshape((-1,1))
+        return predictions
+
+class MGWR(GWR):
+    """
+    Parameters
+    ----------
+        coords        : array-like
+                        n*2, collection of n sets of (x,y) coordinates of
+                        observatons; also used as calibration locations is
+                        'points' is set to None
+
+        y             : array
+                        n*1, dependent variable
+
+        X             : array
+                        n*k, independent variable, exlcuding the constant
+
+        points        : array-like
+                        n*2, collection of n sets of (x,y) coordinates used for
+                        calibration locations; default is set to None, which
+                        uses every observation as a calibration point
+
+        bws           : array-like
+                        collection of bandwidth values consisting of either a distance or N
+                        nearest neighbors; user specified or obtained using
+                        Sel_BW with fb=True. Order of values should the same as
+                        the order of columns associated with X
+        XB            : array
+                        n*k, product of temporary X and params obtained as through-put
+                        from the backfitting algorithm used to select flexible
+                        bandwidths; product of the Sel_BW class
+        err           : array
+                        n*1, temporary residuals associated with the predicted values from
+                        the backfitting algorithm used to select flexible
+                        bandwidths; product of the Sel_BW class
+
+        family        : family object
+                        underlying probability model; provides
+                        distribution-specific calculations
+
+        offset        : array
+                        n*1, the offset variable at the ith location. For Poisson model
+                        this term is often the size of the population at risk or
+                        the expected size of the outcome in spatial epidemiology
+                        Default is None where Ni becomes 1.0 for all locations
+
+        sigma2_v1     : boolean
+                        specify sigma squared, True to use n as denominator;
+                        default is False which uses n-k
+
+        kernel        : string
+                        type of kernel function used to weight observations;
+                        available options:
+                        'gaussian'
+                        'bisquare'
+                        'exponential'
+
+        fixed         : boolean
+                        True for distance based kernel function and  False for
+                        adaptive (nearest neighbor) kernel function (default)
+
+        constant      : boolean
+                        True to include intercept (default) in model and False to exclude
+                        intercept.
+
+    Attributes
+    ----------
+        coords        : array-like
+                        n*2, collection of n sets of (x,y) coordinates of
+                        observatons; also used as calibration locations is
+                        'points' is set to None
+
+        y             : array
+                        n*1, dependent variable
+
+        X             : array
+                        n*k, independent variable, exlcuding the constant
+
+        points        : array-like
+                        n*2, collection of n sets of (x,y) coordinates used for
+                        calibration locations; default is set to None, which
+                        uses every observation as a calibration point
+
+        bws           : array-like
+                        collection of bandwidth values consisting of either a distance or N
+                        nearest neighbors; user specified or obtained using
+                        Sel_BW with fb=True. Order of values should the same as
+                        the order of columns associated with X
+        XB            : array
+                        n*k, product of temporary X and params obtained as through-put
+                        from the backfitting algorithm used to select flexible
+                        bandwidths; product of the Sel_BW class
+        err           : array
+                        n*1, temporary residuals associated with the predicted values from
+                        the backfitting algorithm used to select flexible
+                        bandwidths; product of the Sel_BW class
+
+        family        : family object
+                        underlying probability model; provides
+                        distribution-specific calculations
+
+        offset        : array
+                        n*1, the offset variable at the ith location. For Poisson model
+                        this term is often the size of the population at risk or
+                        the expected size of the outcome in spatial epidemiology
+                        Default is None where Ni becomes 1.0 for all locations
+
+        sigma2_v1     : boolean
+                        specify sigma squared, True to use n as denominator;
+                        default is False which uses n-k
+
+        kernel        : string
+                        type of kernel function used to weight observations;
+                        available options:
+                        'gaussian'
+                        'bisquare'
+                        'exponential'
+
+        fixed         : boolean
+                        True for distance based kernel function and  False for
+                        adaptive (nearest neighbor) kernel function (default)
+
+        constant      : boolean
+                        True to include intercept (default) in model and False to exclude
+                        intercept.
+
+
+    Examples
+    -------
+    TODO
+
+    """
+    def __init__(self, coords, y, X, bws, XB, err, family=Gaussian(), offset=None,
+           sigma2_v1=False, kernel='bisquare', fixed=False, constant=True):
+        """
+        Initialize class
+        """
+        self.coords = coords
+        self.y = y
+        self.X = X
+        self.XB = XB
+        self.err = err
+        self.bws = bws
+        self.family = family
+        self.offset = offset
+        self.sigma2_v1 = sigma2_v1
+        self.kernel = kernel
+        self.fixed = fixed
+        self.constant = constant
+        if constant:
+          self.X = USER.check_constant(self.X)
+
+    def fit(self, ini_params=None, tol=1.0e-5, max_iter=20, solve='iwls'):
+        """
+        Method that fits a model with a particular estimation routine.
+
+        Parameters
+        ----------
+
+        ini_betas     : array
+                        k*1, initial coefficient values, including constant.
+                        Default is None, which calculates initial values during
+                        estimation
+        tol:            float
+                        Tolerence for estimation convergence
+        max_iter      : integer
+                        Maximum number of iterations if convergence not
+                        achieved
+        solve         : string
+                        Technique to solve MLE equations.
+                        'iwls' = iteratively (re)weighted least squares (default)
+
+        """
+        params = np.zeros_like(self.X)
+        err = self.err
+        for i, bw in enumerate(self.bws):
+            W = self._build_W(self.fixed, self.kernel, self.coords, bw)
+            X = self.X[:,i].reshape((-1,1))
+            y = self.XB[:,i].reshape((-1,1)) + err
+            model = GWR(self.coords, y, X, bw, self.family, self.offset,
+                    self.sigma2_v1, self.kernel, self.fixed, constant=False)
+            results = model.fit(ini_params, tol, max_iter, solve)
+            params[:,i] = results.params.flatten()
+            err = results.resid_response.reshape((-1,1))
+        return MGWRResults(self, params)
+
+class MGWRResults(object):
+    """
+    Parameters
+    ----------
+        model               : GWR object
+                              pointer to MGWR object with estimation parameters
+
+        params              : array
+                              n*k, estimated coefficients
+
+    Attributes
+    ----------
+        model               : GWR Object
+                              points to MGWR object for which parameters have been
+                              estimated
+
+        params              : array
+                              n*k, parameter estimates
+
+        predy               : array
+                              n*1, predicted value of y
+
+        y                   : array
+                              n*1, dependent variable
+
+        X                   : array
+                              n*k, independent variable, including constant
+
+                            : array
+        resid_response        n*1, residuals of response
+
+        resid_ss            : scalar
+                              residual sum of sqaures
+
+    Examples
+    -------
+    TODO
+
+    """
+    def __init__(self, model, params):
+        """
+        Initialize class
+        """
+        self.model = model
+        self.params = params
+        self.X = model.X
+        self.y = model.y
+        self._cache = {}
+
+    @cache_readonly
+    def predy(self):
+        return np.sum(np.multiply(self.params, self.X), axis=1).reshape((-1,1))
+
+    @cache_readonly
+    def resid_response(self):
+        return (self.y - self.predy).reshape((-1,1))
+
+    @cache_readonly
+    def resid_ss(self):
+        u = self.resid_response.flatten()
+        return np.dot(u, u.T)

--- a/mgwr/kernels.py
+++ b/mgwr/kernels.py
@@ -1,0 +1,124 @@
+# GWR kernel function specifications
+
+__author__ = "Taylor Oshan tayoshan@gmail.com"
+
+#from pysal.weights.Distance import Kernel
+import scipy
+from scipy.spatial.kdtree import KDTree
+import numpy as np
+
+#adaptive specifications should be parameterized with nn-1 to match original gwr
+#implementation. That is, pysal counts self neighbors with knn automatically.
+
+def fix_gauss(coords, bw, points=None):
+    w = _Kernel(coords, function='gwr_gaussian', bandwidth=bw,
+            truncate=False, points=points)
+    return w.kernel
+
+def adapt_gauss(coords, nn, points=None):
+    w = _Kernel(coords, fixed=False, k=nn-1, function='gwr_gaussian',
+            truncate=False, points=points)
+    return w.kernel
+
+def fix_bisquare(coords, bw, points=None):
+    w = _Kernel(coords, function='bisquare', bandwidth=bw, points=points)
+    return w.kernel
+
+def adapt_bisquare(coords, nn, points=None):
+    w = _Kernel(coords, fixed=False, k=nn-1, function='bisquare', points=points)
+    return w.kernel
+
+def fix_exp(coords, bw, points=None):
+    w = _Kernel(coords, function='exponential', bandwidth=bw,
+            truncate=False, points=points)
+    return w.kernel
+
+def adapt_exp(coords, nn, points=None):
+    w = _Kernel(coords, fixed=False, k=nn-1, function='exponential',
+            truncate=False, points=points)
+    return w.kernel
+
+from scipy.spatial.distance import cdist
+
+#Customized Kernel class user for GWR because the default PySAL kernel class
+#favors memory optimization over speed optimizations and GWR often needs the 
+#speed optimization since it is not always assume points far awar are truncated
+#to zero
+class _Kernel(object):
+    """
+
+    """
+    def __init__(self, data, bandwidth=None, fixed=True, k=None,
+                 function='triangular', eps=1.0000001, ids=None, truncate=True,
+                 points=None): #Added truncate flag
+        if issubclass(type(data), scipy.spatial.KDTree):
+            self.data = data.data
+            data = self.data
+        else:
+            self.data = data
+        if k is not None:
+            self.k = int(k) + 1
+        else:
+            self.k = k
+        if points is None:
+            self.dmat = cdist(self.data, self.data)
+        else:
+            self.points = points
+            self.dmat = cdist(self.points, self.data)
+        self.function = function.lower()
+        self.fixed = fixed
+        self.eps = eps
+        self.trunc = truncate
+        if bandwidth:
+            try:
+                bandwidth = np.array(bandwidth)
+                bandwidth.shape = (len(bandwidth), 1)
+            except:
+                bandwidth = np.ones((len(data), 1), 'float') * bandwidth
+            self.bandwidth = bandwidth
+        else:
+            self._set_bw()
+        self.kernel = self._kernel_funcs(self.dmat/self.bandwidth)
+
+        if self.trunc:
+            mask = np.repeat(self.bandwidth, len(self.data), axis=1)
+            self.kernel[(self.dmat >= mask)] = 0
+
+    def _set_bw(self):
+        if self.k is not None:
+            dmat = np.sort(self.dmat)[:,:self.k]
+        else:
+            dmat = self.dmat
+        if self.fixed:
+            # use max knn distance as bandwidth
+            bandwidth = dmat.max() * self.eps
+            n = len(self.data)
+            self.bandwidth = np.ones((n, 1), 'float') * bandwidth
+        else:
+            # use local max knn distance
+            self.bandwidth = dmat.max(axis=1) * self.eps
+            self.bandwidth.shape = (self.bandwidth.size, 1)
+
+
+    def _kernel_funcs(self, zs):
+        # functions follow Anselin and Rey (2010) table 5.4
+        if self.function == 'triangular':
+            return 1 - zs
+        elif self.function == 'uniform':
+            return np.ones(zi.shape) * 0.5
+        elif self.function == 'quadratic':
+            return (3. / 4) * (1 - zs ** 2)
+        elif self.function == 'quartic':
+            return (15. / 16) * (1 - zs ** 2) ** 2
+        elif self.function == 'gaussian':
+            c = np.pi * 2
+            c = c ** (-0.5)
+            return c * np.exp(-(zs ** 2) / 2.)
+        elif self.function == 'gwr_gaussian':
+            return np.exp(-0.5*(zs)**2)
+        elif self.function == 'bisquare':
+            return (1-(zs)**2)**2
+        elif self.function =='exponential':
+            return np.exp(-zs)
+        else:
+            print('Unsupported kernel function', self.function)

--- a/mgwr/search.py
+++ b/mgwr/search.py
@@ -146,7 +146,7 @@ def equal_interval(l_bound, u_bound, interval, function, int_score=False):
 
 MGWR_BW_Result = namedtuple('MGWR_BW_RESULT', ['bws_','bw_trace', 'kernel_values', 'scores',
                                                'partial_predictions','model_residuals_',
-                                               'partial_residuals_', 'objective_functions'])
+                                               'partial_models_', 'objective_functions'])
 
 def multi_bw(init, y, X, n, k, family, tol, max_iter, rss_score,
         gwr_func, bw_func, sel_func):
@@ -180,7 +180,7 @@ def multi_bw(init, y, X, n, k, family, tol, max_iter, rss_score,
         bws = []
         vals = []
         funcs = []
-        current_partial_residuals = []
+        models = []
         ests = np.zeros_like(X)
         f_XB = XB.copy()
         f_err = err.copy()
@@ -199,7 +199,7 @@ def multi_bw(init, y, X, n, k, family, tol, max_iter, rss_score,
             bws.append(copy.deepcopy(bw))
             ests[:,i] = est
             vals.append(bw_class.bw[1])
-            current_partial_residuals.append(err.copy())
+            models.append(optim_model)
 
         predy = np.sum(np.multiply(ests, X), axis=1).reshape((-1,1))
         num = np.sum((new_XB - XB)**2)/n
@@ -221,4 +221,4 @@ def multi_bw(init, y, X, n, k, family, tol, max_iter, rss_score,
 
     opt_bws = BWs[-1]
     return MGWR_BW_Result(opt_bws, np.array(BWs), np.array(VALs), 
-                          np.array(scores), f_XB, f_err, current_partial_residuals, FUNCs)
+                          np.array(scores), f_XB, f_err, models, FUNCs)

--- a/mgwr/search.py
+++ b/mgwr/search.py
@@ -1,0 +1,218 @@
+#Bandwidth optimization methods
+
+__author__ = "Taylor Oshan"
+
+import numpy as np
+from copy import deepcopy
+import copy
+
+def golden_section(a, c, delta, function, tol, max_iter, int_score=False):
+    """
+    Golden section search routine
+    Method: p212, 9.6.4
+    Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+    Geographically weighted regression: the analysis of spatially varying relationships.
+
+    Parameters
+    ----------
+    a               : float
+                      initial max search section value
+    b               : float
+                      initial min search section value
+    delta           : float
+                      constant used to determine width of search sections
+    function        : function
+                      obejective function to be evaluated at different section
+                      values
+    int_score       : boolean
+                      False for float score, True for integer score
+    tol             : float
+                      tolerance used to determine convergence
+    max_iter        : integer
+                      maximum iterations if no convergence to tolerance
+
+    Returns
+    -------
+    opt_val         : float
+                      optimal value
+    opt_score       : kernel
+                      optimal score
+    output          : list of tuples
+                      searching history
+    """
+    b = a + delta * np.abs(c-a)
+    d = c - delta * np.abs(c-a)
+    score = 0.0
+    diff = 1.0e9
+    iters  = 0
+    output = []
+    while np.abs(diff) > tol and iters < max_iter:
+        iters += 1
+        if int_score:
+          b = np.round(b)
+          d = np.round(d)
+
+        score_a = function(a)
+        score_b = function(b)
+        score_c = function(c)
+        score_d = function(d)
+
+        if score_b <= score_d:
+            opt_val = b
+            opt_score = score_b
+            c = d
+            d = b
+            b = a + delta * np.abs(c-a)
+            #if int_score:
+                #b = np.round(b)
+        else:
+            opt_val = d
+            opt_score = score_d
+            a = b
+            b = d
+            d = c - delta * np.abs(c-a)
+            #if int_score:
+                #d = np.round(b)
+
+        #if int_score:
+        # opt_val = np.round(opt_val)
+        output.append((opt_val, opt_score))
+        diff = score_b - score_d
+        score = opt_score
+    return np.round(opt_val, 2), opt_score, output
+
+def equal_interval(l_bound, u_bound, interval, function, int_score=False):
+    """
+    Interval search, using interval as stepsize
+
+    Parameters
+    ----------
+    l_bound         : float
+                      initial min search section value
+    u_bound         : float
+                      initial max search section value
+    interval        : float
+                      constant used to determine width of search sections
+    function        : function
+                      obejective function to be evaluated at different section
+                      values
+    int_score       : boolean
+                      False for float score, True for integer score
+
+    Returns
+    -------
+    opt_val         : float
+                      optimal value
+    opt_score       : kernel
+                      optimal score
+    output          : list of tuples
+                      searching history
+    """
+    a = l_bound
+    c = u_bound
+    b = a + interval
+    if int_score:
+        a = np.round(a,0)
+        c = np.round(c,0)
+        b = np.round(b,0)
+
+    output = []
+
+    score_a = function(a)
+    score_c = function(c)
+
+    output.append((a,score_a))
+    output.append((c,score_c))
+
+    if score_a < score_c:
+        opt_val = a
+        opt_score = score_a
+    else:
+        opt_val = c
+        opt_score = score_c
+
+    while b < c:
+        score_b = function(b)
+
+        output.append((b,score_b))
+
+        if score_b < opt_score:
+            opt_val = b
+            opt_score = score_b
+        b = b + interval
+
+    return opt_val, opt_score, output
+
+
+def multi_bw(init, y, X, n, k, family, tol, max_iter, rss_score,
+        gwr_func, bw_func, sel_func):
+    if init:
+        bw = sel_func(bw_func(y, X))
+        optim_model = gwr_func(y, X, bw)
+        err = optim_model.resid_response.reshape((-1,1))
+        est = optim_model.params
+    else:
+        model = GLM(y, X, family=self.family, constant=False).fit()
+        err = model.resid_response.reshape((-1,1))
+        est = np.repeat(model.params.T, n, axis=0)
+
+
+    XB = np.multiply(est, X)
+    if rss_score:
+        rss = np.sum((err)**2)
+    iters = 0
+    scores = []
+    delta = 1e6
+    BWs = []
+    VALs = []
+    FUNCs = []
+    try:
+        from tqdm import tqdm
+    except ImportError:
+        def tqdm(x):
+            return x
+    for iters in tqdm(range(1, max_iter+1)):
+        new_XB = np.zeros_like(X)
+        bws = []
+        vals = []
+        funcs = []
+        ests = np.zeros_like(X)
+        f_XB = XB.copy()
+        f_err = err.copy()
+        for i in range(k):
+            temp_y = XB[:,i].reshape((-1,1))
+            temp_y = temp_y + err
+            temp_X = X[:,i].reshape((-1,1))
+            bw_class = bw_func(temp_y, temp_X)
+            funcs.append(bw_class._functions)
+            bw = sel_func(bw_class)
+            optim_model = gwr_func(temp_y, temp_X, bw)
+            err = optim_model.resid_response.reshape((-1,1))
+            est = optim_model.params.reshape((-1,))
+
+            new_XB[:,i] = np.multiply(est, temp_X.reshape((-1,)))
+            bws.append(copy.deepcopy(bw))
+            ests[:,i] = est
+            vals.append(bw_class.bw[1])
+
+        predy = np.sum(np.multiply(ests, X), axis=1).reshape((-1,1))
+        num = np.sum((new_XB - XB)**2)/n
+        den = np.sum(np.sum(new_XB, axis=1)**2)
+        score = (num/den)**0.5
+        XB = new_XB
+
+        if rss_score:
+            new_rss = np.sum((y - predy)**2)
+            score = np.abs((new_rss - rss)/new_rss)
+            rss = new_rss
+        scores.append(copy.deepcopy(score))
+        delta = score
+        BWs.append(copy.deepcopy(bws))
+        VALs.append(copy.deepcopy(vals))
+        FUNCs.append(copy.deepcopy(funcs))
+
+        if delta < tol:
+            break
+
+    opt_bws = BWs[-1]
+    return opt_bws, np.array(BWs), np.array(VALs), np.array(scores), f_XB, f_err, FUNCs

--- a/mgwr/sel_bw.py
+++ b/mgwr/sel_bw.py
@@ -1,0 +1,326 @@
+# GWR Bandwidth selection class
+
+#x_glob parameter does not yet do anything; it is for semiparametric
+
+
+__author__ = "Taylor Oshan Tayoshan@gmail.com"
+
+from .kernels import *
+from .search import golden_section, equal_interval, multi_bw
+from .gwr import GWR
+from pysal.contrib.glm.family import Gaussian, Poisson, Binomial
+import pysal.spreg.user_output as USER
+from .diagnostics import get_AICc, get_AIC, get_BIC, get_CV
+from scipy.spatial.distance import pdist, squareform
+from scipy.optimize import minimize_scalar
+from functools import partial
+import numpy as np
+
+kernels = {1: fix_gauss, 2: adapt_gauss, 3: fix_bisquare, 4:
+        adapt_bisquare, 5: fix_exp, 6:adapt_exp}
+getDiag = {'AICc': get_AICc,'AIC':get_AIC, 'BIC': get_BIC, 'CV': get_CV}
+
+class Sel_BW(object):
+    """
+    Select bandwidth for kernel
+
+    Methods: p211 - p213, bandwidth selection
+    Fotheringham, A. S., Brunsdon, C., & Charlton, M. (2002).
+    Geographically weighted regression: the analysis of spatially varying relationships.
+
+    Parameters
+    ----------
+    y              : array
+                     n*1, dependent variable.
+    X_glob         : array
+                     n*k1, fixed independent variable.
+    X_loc          : array
+                     n*k2, local independent variable, including constant.
+    coords         : list of tuples
+                     (x,y) of points used in bandwidth selection
+    family         : string
+                     GWR model type: 'Gaussian', 'logistic, 'Poisson''
+    offset         : array
+                     n*1, offset variable for Poisson model
+    kernel         : string
+                     kernel function: 'gaussian', 'bisquare', 'exponetial'
+    fixed          : boolean
+                     True for fixed bandwidth and False for adaptive (NN)
+    multi          : True for multiple (covaraite-specific) bandwidths
+                     False for a traditional (same for  all covariates)
+                     bandwdith; defualt is False.
+    constant       : boolean
+                     True to include intercept (default) in model and False to exclude
+                     intercept.
+
+
+    Attributes
+    ----------
+    y              : array
+                     n*1, dependent variable.
+    X_glob         : array
+                     n*k1, fixed independent variable.
+    X_loc          : array
+                     n*k2, local independent variable, including constant.
+    coords         : list of tuples
+                     (x,y) of points used in bandwidth selection
+    family         : string
+                     GWR model type: 'Gaussian', 'logistic, 'Poisson''
+    kernel         : string
+                     type of kernel used and wether fixed or adaptive
+    criterion      : string
+                     bw selection criterion: 'AICc', 'AIC', 'BIC', 'CV'
+    search         : string
+                     bw search method: 'golden', 'interval'
+    bw_min         : float
+                     min value used in bandwidth search
+    bw_max         : float
+                     max value used in bandwidth search
+    interval       : float
+                     interval increment used in interval search
+    tol            : float
+                     tolerance used to determine convergence
+    max_iter       : integer
+                     max interations if no convergence to tol
+    multi          : True for multiple (covaraite-specific) bandwidths
+                     False for a traditional (same for  all covariates)
+                     bandwdith; defualt is False.
+    constant       : boolean
+                     True to include intercept (default) in model and False to exclude
+                     intercept.
+    Examples
+    ________
+
+    >>> import pysal
+    >>> from pysal.contrib.gwr.sel_bw import Sel_BW
+    >>> data = pysal.open(pysal.examples.get_path('GData_utm.csv'))
+    >>> coords = zip(data.bycol('X'), data.by_col('Y')) 
+    >>> y = np.array(data.by_col('PctBach')).reshape((-1,1))
+    >>> rural = np.array(data.by_col('PctRural')).reshape((-1,1))
+    >>> pov = np.array(data.by_col('PctPov')).reshape((-1,1))
+    >>> african_amer = np.array(data.by_col('PctBlack')).reshape((-1,1))
+    >>> X = np.hstack([rural, pov, african_amer])
+    
+    #Golden section search AICc - adaptive bisquare
+    >>> bw = Sel_BW(coords, y, X).search(criterion='AICc')
+    >>> print bw
+    93.0
+
+    #Golden section search AIC - adaptive Gaussian
+    >>> bw = Sel_BW(coords, y, X, kernel='gaussian').search(criterion='AIC')
+    >>> print bw
+    50.0
+
+    #Golden section search BIC - adaptive Gaussian
+    >>> bw = Sel_BW(coords, y, X, kernel='gaussian').search(criterion='BIC')
+    >>> print bw
+    62.0
+
+    #Golden section search CV - adaptive Gaussian
+    >>> bw = Sel_BW(coords, y, X, kernel='gaussian').search(criterion='CV')
+    >>> print bw
+    68.0
+
+    #Interval AICc - fixed bisquare
+    >>>  sel = Sel_BW(coords, y, X, fixed=True).
+    >>>  bw = sel.search(search='interval', bw_min=211001.0, bw_max=211035.0, interval=2) 
+    >>> print bw
+    211025.0
+
+    """
+    def __init__(self, coords, y, X_loc, X_glob=None, family=Gaussian(),
+            offset=None, kernel='bisquare', fixed=False, multi=False, constant=True):
+        self.coords = coords
+        self.y = y
+        self.X_loc = X_loc
+        if X_glob is not None:
+            self.X_glob = X_glob
+        else:
+            self.X_glob = []
+        self.family=family
+        self.fixed = fixed
+        self.kernel = kernel
+        if offset is None:
+          self.offset = np.ones((len(y), 1))
+        else:
+            self.offset = offset * 1.0
+        self.multi = multi
+        self.constant = constant
+        self._functions = []
+
+    def search(self, search='golden_section', criterion='AICc', bw_min=0.0,
+            bw_max=0.0, interval=0.0, tol=1.0e-6, max_iter=200, init_multi=True,
+            tol_multi=1.0e-5, rss_score=False, max_iter_multi=200):
+        """
+        Parameters
+        ----------
+        criterion      : string
+                         bw selection criterion: 'AICc', 'AIC', 'BIC', 'CV'
+        search         : string
+                         bw search method: 'golden', 'interval'
+        bw_min         : float
+                         min value used in bandwidth search
+        bw_max         : float
+                         max value used in bandwidth search
+        interval       : float
+                         interval increment used in interval search
+        tol            : float
+                         tolerance used to determine convergence
+        max_iter       : integer
+                         max iterations if no convergence to tol
+        init_multi     : True to initialize multipke bandwidth search with
+                         esitmates from a traditional GWR and False to
+                         initialize multiple bandwidth search with global
+                         regression estimates
+        tol_multi      : convergence tolerence for the multiple bandwidth
+                         backfitting algorithm; a larger tolerance may stop the
+                         algorith faster though it may result in a less optimal
+                         model
+        max_iter_multi : max iterations if no convergence to tol for multiple
+                         bandwidth backfittign algorithm
+        rss_score      : True to use the residual sum of sqaures to evaluate
+                         each iteration of the multiple bandwidth backfitting
+                         routine and False to use a smooth function; default is
+                         False
+
+        Returns
+        -------
+        bw             : scalar or array
+                         optimal bandwidth value or values; returns scalar for
+                         multi=False and array for multi=True; ordering of bandwidths
+                         matches the ordering of the covariates (columns) of the
+                         designs matrix, X
+        """
+        self.search = search
+        self.criterion = criterion
+        self.bw_min = bw_min
+        self.bw_max = bw_max
+        self.interval = interval
+        self.tol = tol
+        self.max_iter = max_iter
+        self.init_multi = init_multi
+        self.tol_multi = tol_multi
+        self.rss_score = rss_score
+        self.max_iter_multi = max_iter_multi
+
+
+        if self.fixed:
+            if self.kernel == 'gaussian':
+                ktype = 1
+            elif self.kernel == 'bisquare':
+                ktype = 3
+            elif self.kernel == 'exponential':
+                ktype = 5
+            else:
+                raise TypeError('Unsupported kernel function ', self.kernel)
+        else:
+            if self.kernel == 'gaussian':
+              ktype = 2
+            elif self.kernel == 'bisquare':
+                ktype = 4
+            elif self.kernel == 'exponential':
+                ktype = 6
+            else:
+                raise TypeError('Unsupported kernel function ', self.kernel)
+
+        def function(bw):
+            return getDiag[criterion](GWR(self.coords, self.y, self.x_loc, bw, family=self.family,
+                                          kernel=self.kernel, fixed=self.fixed, offset=self.offset).fit())
+
+        if ktype % 2 == 0:
+            int_score = True
+        else:
+            int_score = False
+        self.int_score = int_score
+
+        if self.multi:
+            self._mbw()
+            self.XB = self.bw[4]
+            self.err = self.bw[5]
+        else:
+            self._bw()
+
+        return self.bw[0]
+
+    def _bw(self):
+        def gwr_func(bw):
+            return getDiag[self.criterion](
+                    GWR(self.coords, self.y, self.X_loc, bw, family=self.family,
+                        kernel=self.kernel, fixed=self.fixed, constant=self.constant).fit())
+        self._functions.append(gwr_func)
+        if self.search == 'golden_section':
+            a,c = self._init_section(self.X_glob, self.X_loc, self.coords,
+                    self.constant)
+            delta = 0.38197 #1 - (np.sqrt(5.0)-1.0)/2.0
+            self.bw = golden_section(a, c, delta, gwr_func, self.tol,
+                    self.max_iter, self.int_score)
+        elif self.search == 'interval':
+            self.bw = equal_interval(self.bw_min, self.bw_max, self.interval,
+                    gwr_func, self.int_score)
+        elif self.search == 'scipy':
+            self.bw_min, self.bw_max = self._init_section(self.X_glob, self.X_loc, self.coords, self.constant)
+            if self.bw_min == self.bw_max:
+                raise Exception('Maximum bandwidth and minimum bandwidth must be distinct for scipy optimizer.')
+            self._optimize_result = minimize_scalar(gwr_func, bounds=(self.bw_min, self.bw_max), method='bounded')
+            self.bw = [self._optimize_result.x, self._optimize_result.fun, []]
+        else:
+            raise TypeError('Unsupported computational search method ', search)
+
+    def _mbw(self):
+        y = self.y
+        if self.constant:
+          X = USER.check_constant(self.X_loc)
+        else:
+            X = self.X_loc
+        n, k = X.shape
+        family = self.family
+        offset = self.offset
+        kernel = self.kernel
+        fixed = self.fixed
+        coords = self.coords
+        search = self.search
+        criterion = self.criterion
+        bw_min = self.bw_min
+        bw_max = self.bw_max
+        interval = self.interval
+        tol = self.tol
+        max_iter = self.max_iter
+        def gwr_func(y,X,bw):
+            return GWR(coords, y,X,bw,family=family, kernel=kernel, fixed=fixed, offset=offset, constant=False).fit()
+        def bw_func(y,X):
+            return Sel_BW(coords, y,X,X_glob=[], family=family, kernel=kernel, fixed=fixed, offset=offset, constant=False)
+        def sel_func(bw_func):
+            return bw_func.search(search=search, criterion=criterion, bw_min=bw_min, 
+                           bw_max=bw_max, interval=interval, tol=tol, max_iter=max_iter)
+        self.bw = multi_bw(self.init_multi, y, X, n, k, family,
+                self.tol_multi, self.max_iter_multi, self.rss_score, gwr_func,
+                bw_func, sel_func)
+
+    def _init_section(self, X_glob, X_loc, coords, constant):
+        if len(X_glob) > 0:
+            n_glob = X_glob.shape[1]
+        else:
+            n_glob = 0
+        if len(X_loc) > 0:
+            n_loc = X_loc.shape[1]
+        else:
+            n_loc = 0
+        if constant:
+            n_vars = n_glob + n_loc + 1
+        else:
+            n_vars = n_glob + n_loc
+        n = np.array(coords).shape[0]
+
+        if self.int_score:
+            a = 40 + 2 * n_vars
+            c = n
+        else:
+            sq_dists = pdist(coords)
+            a = np.min(sq_dists)/2.0
+            c = np.max(sq_dists)*2.0
+
+        if a < self.bw_min:
+            a = self.bw_min
+        if c > self.bw_max and self.bw_max > 0:
+            c = self.bw_max
+        return a, c


### PR DESCRIPTION
This does three things. 

1. swaps the lambdas for def statements. I think these actually should be `functools.partial` assignments, since I'm not sure totally whether the `def`... creates a closure around the objects, but I *know* lambda does not. 
2. changes the default search distances for the fixed bandwidths to be half the minimum interpoint distance to twice the maximum interpoint distance. Before, it was half the minimum to half the maximum. This lead `golden_section` to find a sub-optimal fixed bandwidth in the georgia example. 
3. add a `scipy` option to the bandwidth search, which uses `scipy.optimize.minimize_scalar` to minimize the bandwidth. In [timings](https://gist.github.com/anonymous/0e6b69eb3764d57eb23552a8e43126bf) this can be faster for fixed bandwidths. 