### PR TITLE
Global r2

### DIFF
--- a/gwr/gwr.py
+++ b/gwr/gwr.py
@@ -847,6 +847,14 @@ class GWRResults(GLMResults):
         raise NotImplementedError('Not implemented for GWR')
 
     @cache_readonly
+    def R2(self):
+        if isinstance(self.family, Gaussian):
+            RSS = np.sum((self.y.reshape((-1,1)) - np.mean(y))**2)
+            TSS = np.sum((self.y.reshape((-1,1)) -
+                self.predy.reshape((-1,1)))**2)
+            return 1 - (RSS / TSS)
+
+    @cache_readonly
     def aic(self):
         return get_AIC(self)
 

--- a/gwr/gwr.py
+++ b/gwr/gwr.py
@@ -853,6 +853,8 @@ class GWRResults(GLMResults):
             RSS = np.sum((self.y.reshape((-1,1)) -
                 self.predy.reshape((-1,1)))**2)
             return 1 - (RSS / TSS)
+        else:
+            raise NotImplementedError('Only available for Gaussian GWR')
 
     @cache_readonly
     def aic(self):

--- a/gwr/gwr.py
+++ b/gwr/gwr.py
@@ -849,8 +849,8 @@ class GWRResults(GLMResults):
     @cache_readonly
     def R2(self):
         if isinstance(self.family, Gaussian):
-            RSS = np.sum((self.y.reshape((-1,1)) - np.mean(y))**2)
-            TSS = np.sum((self.y.reshape((-1,1)) -
+            TSS = np.sum((self.y.reshape((-1,1)) - np.mean(self.y.reshape((-1,1))))**2)
+            RSS = np.sum((self.y.reshape((-1,1)) -
                 self.predy.reshape((-1,1)))**2)
             return 1 - (RSS / TSS)
 

--- a/gwr/tests/test_gwr.py
+++ b/gwr/tests/test_gwr.py
@@ -53,7 +53,7 @@ class TestGWRGaussian(unittest.TestCase):
         AIC = get_AIC(rslt)
         BIC = get_BIC(rslt)
         CV = get_CV(rslt)
-        
+
         self.assertAlmostEquals(np.floor(AICc), 894.0)
         self.assertAlmostEquals(np.floor(AIC), 890.0)
         self.assertAlmostEquals(np.floor(BIC), 944.0)
@@ -104,7 +104,9 @@ class TestGWRGaussian(unittest.TestCase):
         AIC = get_AIC(rslt)
         BIC = get_BIC(rslt)
         CV = get_CV(rslt)
-        
+        R2 = rslt.R2
+
+        self.assertAlmostEquals(np.around(R2, 4), 0.5924)
         self.assertAlmostEquals(np.floor(AICc), 896.0)
         self.assertAlmostEquals(np.floor(AIC), 892.0)
         self.assertAlmostEquals(np.floor(BIC), 941.0)


### PR DESCRIPTION
The following PR adds method to provide global R2 value to evaluate Gaussian GWR compared to OLS global model and satisfies the suggestion put forth in #7.